### PR TITLE
Add Simulation section to bdm.toml file example.

### DIFF
--- a/doc/user_guide/docs/visualization.md
+++ b/doc/user_guide/docs/visualization.md
@@ -19,7 +19,7 @@ One way to enable visualization is to export a visualization file every time ste
 
 ```
 [simulation]
-/// For other simulations certain parameters would also need to be defined within this section of the toml file.
+# For other simulations certain parameters would also need to be defined within this section of the toml file.
 [visualization]
 export = true
 export_interval = 1

--- a/doc/user_guide/docs/visualization.md
+++ b/doc/user_guide/docs/visualization.md
@@ -18,6 +18,8 @@ One way to enable visualization is to export a visualization file every time ste
 (or every N time steps). In the `bmd.toml` file add the following lines:
 
 ```
+[simulation]
+/// For other simulations certain parameters would also need to be defined within this section of the toml file.
 [visualization]
 export = true
 export_interval = 1


### PR DESCRIPTION
To make it more clear to users that there are two parts to the bdm.toml file I believe the simulation part should also be included in this example.