### PR TITLE
Inccorect coordinate

### DIFF
--- a/src/core/substance_initializers.h
+++ b/src/core/substance_initializers.h
@@ -151,7 +151,7 @@ struct PoissonBand {
       case Axis::kYAxis:
         return ROOT::Math::poisson_pdf(y, lambda_);
       case Axis::kZAxis:
-        return ROOT::Math::poisson_pdf(y, lambda_);
+        return ROOT::Math::poisson_pdf(z, lambda_);
       default:
         throw std::logic_error("You have chosen an non-existing axis!");
     }


### PR DESCRIPTION
it seems the Y coordinate was used accidentally instead of the Z coordinate here for initialisation.