### PR TITLE
Document naming requirements for Biology modules.

### DIFF
--- a/doc/user_guide/docs/jean_tuto.md
+++ b/doc/user_guide/docs/jean_tuto.md
@@ -85,7 +85,7 @@ In the previous chapter, we created a great number of cells. However, those cell
     BDM_CLASS_DEF_NV(GrowthModule, 1);
   };
 ```
-
+The names of user-defined Biology modules have to be postfixed by `BM`, `Module` or `Behaviour`.
 We are now able to add any code in the Run() method, that will be executed at each simulation step for each cell containing this GrowthModule. In our case, it will be a cellular growth, until a certain diameter is reached and then a cell division:
 ``` C++
       if (cell->GetDiameter() < 8) {


### PR DESCRIPTION
Mention that the names of user-defined Biology modules have to be postfixed by `BM`, `Module` or `Behaviour`.
(see cmake/selection.xml)
I have not seen this restriction being mentioned anywhere and the associated error messages are not very informative.

example error message when naming a Biology module 'NAME':
CMakeFiles/test.dir/test_custom_streamers_dict.cc.o: In function `ROOT::streamer_bdmcLcLVariantlEbdmcLcLNAMEgR(TBuffer&, void*)':
test_custom_streamers_dict.cc:(.text+0x120a): undefined reference to `bdm::NAME::Class()'
test_custom_streamers_dict.cc:(.text+0x12b4): undefined reference to `bdm::NAME::Class()'
collect2: error: ld returned 1 exit status
make[2]: *** [test] Error 1
make[1]: *** [CMakeFiles/test.dir/all] Error 2
make: *** [all] Error 2
Compilation failed. Check the debug output above.