### PR TITLE
Add MathArray container.

### DIFF
--- a/src/core/container/math_array.h
+++ b/src/core/container/math_array.h
@@ -17,6 +17,7 @@
 
 #include <algorithm>
 #include <cassert>
+#include <cmath>
 #include <stdexcept>
 #include <utility>
 
@@ -28,7 +29,7 @@ namespace bdm {
 template <class T, std::size_t N>
 class MathArray {  // NOLINT
  public:
-  MathArray(){}
+  MathArray() {}
   MathArray(std::initializer_list<T> l) : MathArray<T, N>() {
     assert(l.size() == N);
     std::copy(l.begin(), l.end(), &data_[0]);
@@ -45,7 +46,7 @@ class MathArray {  // NOLINT
   T& at(size_t idx) {  // NOLINT
     if (idx > size() || idx < 0) {
       throw std::out_of_range("The index is out of range");
-}
+    }
     return data_[idx];
   }
 
@@ -76,11 +77,11 @@ class MathArray {  // NOLINT
   bool operator==(const MathArray& other) const {
     if (other.size() != N) {
       return false;
-}
+    }
     for (size_t i = 0; i < N; i++) {
       if (other[i] != data_[i]) {
         return false;
-}
+      }
     }
     return true;
   }

--- a/src/core/container/math_array.h
+++ b/src/core/container/math_array.h
@@ -24,16 +24,27 @@
 namespace bdm {
 
 /// Array with a fixed number of elements. It implements the same behaviour
-/// of the standard `std::array<T, N>` container. However, it provides also
+/// of the standard `MathArray<T, N>` container. However, it provides also
 /// several custom mathematical operations (e.g. Sum(), Norm() etc.).
 template <class T, std::size_t N>
 class MathArray {  // NOLINT
  public:
-  MathArray() {}
-  MathArray(std::initializer_list<T> l) : MathArray<T, N>() {
-    assert(l.size() == N);
-    std::copy(l.begin(), l.end(), &data_[0]);
+  constexpr MathArray() : data_() {
+	  /// std::fill will become constexpr with C++20
+	  for (size_t i=0; i<N; i++)
+	  {
+		  data_[i] = 0;
+	  }
   }
+  constexpr MathArray(std::initializer_list<T> l) : MathArray<T, N>() {
+    assert(l.size() == N);
+	for (size_t i=0; i<N; i++)
+	{
+	  data_[i] = *(l.begin()+i);
+	}
+  }
+
+  inline const T* data() const { return &data_[0]; }  // NOLINT
 
   inline const size_t size() const { return N; }  // NOLINT
 
@@ -69,7 +80,7 @@ class MathArray {  // NOLINT
   MathArray& operator=(const MathArray& other) {
     if (this != &other) {
       assert(other.size() == N);
-      std::copy(other.data_, other.data_ + other.N, data_);
+      std::copy(other.data_, other.data_ + other.size(), data_);
     }
     return *this;
   }
@@ -219,11 +230,8 @@ class MathArray {  // NOLINT
     return tmp;
   }
 
-  MathArray& Fill(const T& k) {
-#pragma omp simd
-    for (size_t i = 0; i < N; i++) {
-      data_[i] = k;
-    }
+  MathArray& fill(const T& k) {  // NOLINT
+	std::fill(std::begin(data_), std::end(data_), k);
     return *this;
   }
 

--- a/src/core/container/math_array.h
+++ b/src/core/container/math_array.h
@@ -12,8 +12,8 @@
 //
 // -----------------------------------------------------------------------------
 
-#ifndef CORE_CONTAINER_MATH_ARRAY_
-#define CORE_CONTAINER_MATH_ARRAY_
+#ifndef CORE_CONTAINER_MATH_ARRAY_H_
+#define CORE_CONTAINER_MATH_ARRAY_H_
 
 #include <algorithm>
 #include <cassert>
@@ -31,18 +31,16 @@ template <class T, std::size_t N>
 class MathArray {  // NOLINT
  public:
   constexpr MathArray() : data_() {
-	  /// std::fill will become constexpr with C++20
-	  for (size_t i=0; i<N; i++)
-	  {
-		  data_[i] = 0;
-	  }
+    /// std::fill will become constexpr with C++20
+    for (size_t i = 0; i < N; i++) {
+      data_[i] = 0;
+    }
   }
   constexpr MathArray(std::initializer_list<T> l) : MathArray<T, N>() {
     assert(l.size() == N);
-	for (size_t i=0; i<N; i++)
-	{
-	  data_[i] = *(l.begin()+i);
-	}
+    for (size_t i = 0; i < N; i++) {
+      data_[i] = *(l.begin() + i);
+    }
   }
 
   inline const T* data() const { return &data_[0]; }  // NOLINT
@@ -232,7 +230,7 @@ class MathArray {  // NOLINT
   }
 
   MathArray& fill(const T& k) {  // NOLINT
-	std::fill(std::begin(data_), std::end(data_), k);
+    std::fill(std::begin(data_), std::end(data_), k);
     return *this;
   }
 

--- a/src/core/container/math_array.h
+++ b/src/core/container/math_array.h
@@ -18,6 +18,7 @@
 #include <algorithm>
 #include <cassert>
 #include <cmath>
+#include <numeric>
 #include <stdexcept>
 #include <utility>
 

--- a/src/core/container/math_array.h
+++ b/src/core/container/math_array.h
@@ -1,0 +1,259 @@
+// -----------------------------------------------------------------------------
+//
+// Copyright (C) The BioDynaMo Project.
+// All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// See the LICENSE file distributed with this work for details.
+// See the NOTICE file distributed with this work for additional information
+// regarding copyright ownership.
+//
+// -----------------------------------------------------------------------------
+
+#ifndef CORE_CONTAINER_MATH_ARRAY_
+#define CORE_CONTAINER_MATH_ARRAY_
+
+#include <algorithm>
+#include <cassert>
+#include <stdexcept>
+#include <utility>
+
+namespace bdm {
+
+/// Array with a fixed number of elements. It implements the same behaviour
+/// of the standard `std::array<T, N>` container. However, it provides also
+/// several custom mathematical operations (e.g. Sum(), Norm() etc.).
+template <class T, std::size_t N>
+class MathArray {  // NOLINT
+ public:
+  MathArray(){}
+  MathArray(std::initializer_list<T> l) : MathArray<T, N>() {
+    assert(l.size() == N);
+    std::copy(l.begin(), l.end(), &data_[0]);
+  }
+
+  inline const size_t size() const { return N; }  // NOLINT
+
+  inline const bool empty() const { return N == 0; }  // NOLINT
+
+  T& operator[](size_t idx) { return data_[idx]; }
+
+  const T& operator[](size_t idx) const { return data_[idx]; }
+
+  T& at(size_t idx) {  // NOLINT
+    if (idx > size() || idx < 0) {
+      throw std::out_of_range("The index is out of range");
+}
+    return data_[idx];
+  }
+
+  const T* begin() const { return &(data_[0]); }  // NOLINT
+
+  const T* end() const { return &(data_[N]); }  // NOLINT
+
+  T* begin() { return &(data_[0]); }  // NOLINT
+
+  T* end() { return &(data_[N]); }  // NOLINT
+
+  T& front() { return *(this->begin()); }  // NOLINT
+
+  T& back() {  // NOLINT
+    auto tmp = this->end();
+    tmp--;
+    return *tmp;
+  }
+
+  MathArray& operator=(const MathArray& other) {
+    if (this != &other) {
+      assert(other.size() == N);
+      std::copy(other.data_, other.data_ + other.N, data_);
+    }
+    return *this;
+  }
+
+  bool operator==(const MathArray& other) const {
+    if (other.size() != N) {
+      return false;
+}
+    for (size_t i = 0; i < N; i++) {
+      if (other[i] != data_[i]) {
+        return false;
+}
+    }
+    return true;
+  }
+
+  MathArray& operator++() {
+#pragma omp simd
+    for (size_t i = 0; i < N; i++) {
+      ++data_[i];
+    }
+    return *this;
+  }
+
+  MathArray operator++(int) {
+    MathArray<T, N> tmp(*this);
+    operator++();
+    return tmp;
+  }
+
+  MathArray& operator--() {
+#pragma omp simd
+    for (size_t i = 0; i < N; i++) {
+      --data_[i];
+    }
+    return *this;
+  }
+
+  MathArray operator--(int) {
+    MathArray<T, N> tmp(*this);
+    operator--();
+    return tmp;
+  }
+
+  MathArray& operator+=(const MathArray& rhs) {
+    assert(N == rhs.size());
+#pragma omp simd
+    for (size_t i = 0; i < N; i++) {
+      data_[i] += rhs[i];
+    }
+    return *this;
+  }
+
+  MathArray operator+(const MathArray& rhs) {
+    assert(size() == rhs.size());
+    MathArray tmp(*this);
+    tmp += rhs;
+    return tmp;
+  }
+
+  MathArray& operator+=(const T& rhs) {
+    assert(N == rhs.size());
+#pragma omp simd
+    for (size_t i = 0; i < N; i++) {
+      data_[i] += rhs;
+    }
+    return *this;
+  }
+
+  MathArray operator+(const T& rhs) {
+    assert(size() == rhs.size());
+    MathArray tmp(*this);
+    tmp += rhs;
+    return tmp;
+  }
+
+  MathArray& operator-=(const MathArray& rhs) {
+    assert(size() == rhs.size());
+#pragma omp simd
+    for (size_t i = 0; i < N; i++) {
+      data_[i] -= rhs[i];
+    }
+    return *this;
+  }
+
+  MathArray operator-(const MathArray& rhs) {
+    assert(size() == rhs.size());
+    MathArray tmp(*this);
+    tmp -= rhs;
+    return tmp;
+  }
+
+  MathArray& operator-=(const T& rhs) {
+    assert(size() == rhs.size());
+#pragma omp simd
+    for (size_t i = 0; i < N; i++) {
+      data_[i] -= rhs;
+    }
+    return *this;
+  }
+
+  MathArray operator-(const T& rhs) {
+    assert(size() == rhs.size());
+    MathArray tmp(*this);
+    tmp -= rhs;
+    return tmp;
+  }
+
+  T& operator*=(const MathArray& rhs) = delete;
+
+  T operator*(const MathArray& rhs) {
+    assert(size() == rhs.size());
+    T result = 0;
+#pragma omp simd
+    for (size_t i = 0; i < N; i++) {
+      result += data_[i] * rhs[i];
+    }
+    return result;
+  }
+
+  MathArray& operator*=(const T& k) {
+#pragma omp simd
+
+    for (size_t i = 0; i < N; i++) {
+      data_[i] *= k;
+    }
+    return *this;
+  }
+
+  MathArray operator*(const T& k) {
+    MathArray tmp(*this);
+    tmp *= k;
+    return tmp;
+  }
+
+  MathArray& operator/=(const T& k) {
+#pragma omp simd
+    for (size_t i = 0; i < N; i++) {
+      data_[i] /= k;
+    }
+    return *this;
+  }
+
+  MathArray operator/(const T& k) {
+    MathArray tmp(*this);
+    tmp /= k;
+    return tmp;
+  }
+
+  MathArray& Fill(const T& k) {
+#pragma omp simd
+    for (size_t i = 0; i < N; i++) {
+      data_[i] = k;
+    }
+    return *this;
+  }
+
+  T Sum() const { return std::accumulate(begin(), end(), 0); }
+
+  T Norm() const {
+    T result = 0;
+#pragma omp simd
+    for (size_t i = 0; i < N; i++) {
+      result += data_[i] * data_[i];
+    }
+    result = std::sqrt(result);
+
+    return result == 0 ? 1.0 : result;
+  }
+
+  MathArray& Normalize() {
+    T norm = Norm();
+#pragma omp simd
+    for (size_t i = 0; i < N; i++) {
+      data_[i] /= norm;
+    }
+    return *this;
+  }
+
+ private:
+  T data_[N];
+};
+
+using Double3 = MathArray<double, 3>;
+
+}  // namespace bdm
+
+#endif  // CORE_CONTAINER_MATH_ARRAY_H_

--- a/test/unit/core/container/math_array_test.cc
+++ b/test/unit/core/container/math_array_test.cc
@@ -85,7 +85,7 @@ TEST(MathArray, complex_operations) {
   MathArray<double, 4> fill_result{1, 1, 1, 1};
   MathArray<double, 4> normalize_result{0.5, 0.5, 0.5, 0.5};
 
-  a.Fill(1);
+  a.fill(1);
   ASSERT_EQ(a, fill_result);
 
   ASSERT_EQ(a.Sum(), 4);

--- a/test/unit/core/container/math_array_test.cc
+++ b/test/unit/core/container/math_array_test.cc
@@ -1,0 +1,99 @@
+// -----------------------------------------------------------------------------
+//
+// Copyright (C) The BioDynaMo Project.
+// All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// See the LICENSE file distributed with this work for details.
+// See the NOTICE file distributed with this work for additional information
+// regarding copyright ownership.
+//
+// -----------------------------------------------------------------------------
+
+#include "core/container/math_array.h"
+#include "gtest/gtest.h"
+
+namespace bdm {
+
+TEST(MathArray, element_access) {
+  MathArray<double, 4> real_vector{0, 1, 2, 3};
+
+  for (int i = 0; i < 4; i++) {
+    ASSERT_EQ(real_vector.at(i), i);
+    ASSERT_EQ(real_vector[i], i);
+  }
+
+  ASSERT_EQ(real_vector.front(), 0);
+  ASSERT_EQ(real_vector.back(), 3);
+
+  int i = 0;
+  for (auto e : real_vector) {
+    ASSERT_EQ(e, real_vector[i]);
+    i++;
+  }
+}
+
+TEST(MathArray, capacity) {
+  MathArray<double, 4> real_vector{0, 1, 2, 3};
+  MathArray<double, 0> real_vector_empty;
+
+  ASSERT_EQ(real_vector.size(), 4u);
+  ASSERT_EQ(real_vector_empty.size(), 0u);
+
+  ASSERT_FALSE(real_vector.empty());
+  ASSERT_TRUE(real_vector_empty.empty());
+}
+
+TEST(MathArray, math_operators) {
+  MathArray<double, 4> a{0, 1, 2, 3};
+  MathArray<double, 4> b{0, 1, 2, 3};
+
+  MathArray<double, 4> sum_result{0, 2, 4, 6};
+  MathArray<double, 4> sub_result{0, 0, 0, 0};
+  MathArray<double, 4> scalar_mult_result{0, 3, 6, 9};
+  MathArray<double, 4> scalar_division_result{0, 0.5, 1, 1.5};
+  MathArray<double, 4> increment_result{1, 2, 3, 4};
+  MathArray<double, 4> decrement_result{-1, 0, 1, 2};
+
+  ASSERT_EQ(a + b, sum_result);
+
+  ASSERT_EQ(a - b, sub_result);
+
+  ASSERT_EQ(a * b, 14);
+
+  ASSERT_EQ(a * 3, scalar_mult_result);
+
+  ASSERT_EQ(a + 1, increment_result);
+
+  ASSERT_EQ(a - 1, decrement_result);
+
+  ASSERT_EQ(a / 2, scalar_division_result);
+
+  a++;
+  ASSERT_EQ(a, increment_result);
+
+  b--;
+  ASSERT_EQ(b, decrement_result);
+}
+
+TEST(MathArray, complex_operations) {
+  MathArray<double, 4> a;
+  MathArray<double, 4> b{0, 0, 0, 0};
+
+  MathArray<double, 4> fill_result{1, 1, 1, 1};
+  MathArray<double, 4> normalize_result{0.5, 0.5, 0.5, 0.5};
+
+  a.Fill(1);
+  ASSERT_EQ(a, fill_result);
+
+  ASSERT_EQ(a.Sum(), 4);
+
+  ASSERT_EQ(a.Norm(), 2);
+
+  ASSERT_EQ(a.Normalize(), normalize_result);
+
+  ASSERT_EQ(b.Norm(), 1);
+}
+}  // namespace bdm


### PR DESCRIPTION
It provides a similar interface to the one of `std::array<T, std::size_t>`, but it also overloads mathematical operations. For instance, it is possible to do now:
```c++
MathArray a{1,2,3}; 
MathArray b{1,1,1};

auto c = a+b; // c <-- {2,3,4}
a.Sum(); // 6
```

Changes:
* Overload ++ and --;
* Overload +, -, +=, -=, * and *= (both for MathArray and scalars);
* Overload / and /= (only for scalars);
* Add Sum(), Norm(), Normalize() methods;
* Add MathArray unit tests.