### PR TITLE
Set Docker locale on Ubuntu image.

### DIFF
--- a/util/installation/ubuntu-16.04/Dockerfile
+++ b/util/installation/ubuntu-16.04/Dockerfile
@@ -45,3 +45,7 @@ USER testuser
 # preserve the environment variable BDM_LOCAL_LFS when calling scripts with
 # sudo
 RUN echo "Defaults env_keep += \"BDM_LOCAL_LFS\"" | sudo tee -a /etc/sudoers
+
+# Export locales
+ENV LANG C.UTF-8
+ENV LC_ALL C.UTF-8

--- a/util/run-inside-docker.sh
+++ b/util/run-inside-docker.sh
@@ -107,6 +107,13 @@ if [ $TRAVIS ]; then
     BDM_FORWARD_ENV="$BDM_FORWARD_ENV --env=$e"
   done
 fi
+
+# Add also locale variables only for Ubuntu 16.04. This is needed by mkdocs
+# when we need to deploy the documentation.
+if [ ${BDM_OS} = "ubuntu-16.04" ]; then
+  BDM_FORWARD_ENV="$BDM_FORWARD_ENV --env LANG=C.UTF-8 --env LC_ALL=C.UTF-8"
+fi
+
 # flattening the image somehow resets the default user specified in the
 # Dockerfile to root. Therefore, we have to add the --user option here
 sudo docker run \


### PR DESCRIPTION
This is needed to make mkdoc work. It prevents this error from happening:
```bash
Traceback (most recent call last):
  File "/home/testuser/.local/bin/mkdocs", line 11, in <module>
    sys.exit(cli())
  File "/home/testuser/.local/lib/python3.5/site-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/home/testuser/.local/lib/python3.5/site-packages/click/core.py", line 696, in main
    _verify_python3_env()
  File "/home/testuser/.local/lib/python3.5/site-packages/click/_unicodefun.py", line 124, in _verify_python3_env
    ' mitigation steps.' + extra
RuntimeError: Click will abort further execution because Python 3 was configured to use ASCII as encoding for the environment. Consult https://click.palletsprojects.com/en/7.x/python3/ for mitigation steps.
This system supports the C.UTF-8 locale which is recommended.
You might be able to resolve your issue by exporting the
following environment variables:
    export LC_ALL=C.UTF-8
    export LANG=C.UTF-8
```
See http://click.palletsprojects.com/en/5.x/python3/