### PR TITLE
Change RPath such to relocate easily the build directory.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -311,6 +311,7 @@ set(CMAKE_BUILD_RPATH "")
 set(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
 set(CMAKE_SKIP_BUILD_RPATH TRUE) # skip the full RPATH for the build tree
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH FALSE)
+set(CMAKE_MACOSX_RPATH TRUE) # use @rpath keyword for the MacOS rpath
 
 # -------------------- extract third party libraries ---------------------------
 set(EXTRACTED_THIRD_PARTY_LIBS "${CMAKE_CURRENT_BINARY_DIR}/extracted-third-party-libs")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -309,7 +309,7 @@ include(SetCompilerFlags)
 set(CMAKE_INSTALL_RPATH "")
 set(CMAKE_BUILD_RPATH "")
 set(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
-set(CMAKE_SKIP_BUILD_RPATH FALSE) # don't skip the full RPATH for the build tree
+set(CMAKE_SKIP_BUILD_RPATH TRUE) # skip the full RPATH for the build tree
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH FALSE)
 
 # -------------------- extract third party libraries ---------------------------

--- a/cmake/FindROOT.cmake
+++ b/cmake/FindROOT.cmake
@@ -47,7 +47,7 @@ execute_process(
     OUTPUT_STRIP_TRAILING_WHITESPACE)
 set(ROOT_LIBRARY_DIRS ${ROOT_LIBRARY_DIR})
 
-set(rootlibs Core RIO Net Hist Graf Graf3d Gpad Tree Rint Postscript Matrix Physics MathCore Thread MultiProc)
+set(rootlibs Core RIO Net Hist Graf Graf3d Gpad Tree Rint Postscript Matrix Physics MathCore Thread MultiProc Imt)
 set(ROOT_LIBRARIES)
 foreach(_cpt ${rootlibs} ${ROOT_FIND_COMPONENTS})
   find_library(ROOT_${_cpt}_LIBRARY ${_cpt} HINTS ${ROOT_LIBRARY_DIR})


### PR DESCRIPTION
This way it will be more easy to relocate the build directory and use biodynamo from there. Not having the rpath will force us to source anytime the `thisbdm.sh` script, which is, however, a mandatory
step in order to use the library.