### PR TITLE
Refactor GPU code for dynamic runtime

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -290,6 +290,22 @@ the prerequistes.sh script offered by the library. Then run again cmake (with th
     endif()
 endif()
 
+# Link to OpenCL
+if (OPENCL_FOUND)
+  if (OPENCL_HAS_CXX)
+    add_definitions("-DUSE_OPENCL")
+    set(BDM_REQUIRED_LIBRARIES ${BDM_REQUIRED_LIBRARIES} ${OPENCL_LIBRARIES})
+  else()
+    message(WARNING "OpenCL C++ bindings not found. Please install to make use of OpenCL. "
+      "If you think you have installed the C++ bindings correctly, please check if one "
+      "of the following environmentals is set correctly (vendor specific):
+      - AMD: \t\tAMDAPPSDKROOT
+      - NVIDIA: \tCUDA_PATH
+      - INTEL: \tINTELOPENCLSDK")
+    set(OPENCL_FOUND FALSE)
+  endif()
+endif()
+
 # -------------------- includes -----------------------------------------------
 include(BioDynaMo)
 include(ExternalProject)
@@ -341,18 +357,6 @@ build_libbiodynamo(biodynamo
                    LIBRARIES ${BDM_REQUIRED_LIBRARIES} ${ROOT_LIBRARIES})
 if(${VTune_FOUND})
   target_link_libraries(biodynamo ${VTUNE_LIBRARIES})
-endif()
-
-# Check if OpenCL C++ bindings are installed
-if (OPENCL_FOUND)
-  if (NOT OPENCL_HAS_CXX)
-    message(FATAL_ERROR "OpenCL C++ bindings not found. Please install to make use of OpenCL. "
-      "If you think you have installed the C++ bindings correctly, please check if one "
-      "of the following environmentals is set correctly (vendor specific):
-      - AMD: \t\tAMDAPPSDKROOT
-      - NVIDIA: \tCUDA_PATH
-      - INTEL: \tINTELOPENCLSDK")
-  endif()
 endif()
 
 set(CMAKE_SUPPRESS_DEVELOPER_WARNINGS 1 CACHE BOOL "Suppress cmake development warnings")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -463,8 +463,8 @@ if (test)
   if (NOT coverage)
     if(OPENCL_FOUND OR CUDA_FOUND)
       bdm_add_executable(cell_division_gpu
-                         SOURCES test/system/cell_division_gpu.cc
-                         HEADERS test/system/cell_division_gpu.h
+                         SOURCES test/system/cell_division_gpu/src/cell_division_gpu.cc
+                         HEADERS test/system/cell_division_gpu/src/cell_division_gpu.h
                          LIBRARIES biodynamo)
       add_dependencies(check cell_division_gpu)
       add_test(NAME "system-cell-division-gpu"

--- a/cmake/UseBioDynaMo.cmake.in
+++ b/cmake/UseBioDynaMo.cmake.in
@@ -129,13 +129,11 @@ if(paraview)
 endif()
 
 # paraview version 5.5 (MacOS) does not contain TBB
-if (APPLE OR (NOT paraview OR NOT ${ParaView_FOUND}))
-  find_package(TBB REQUIRED)
-  if (TBB_FOUND)
-    include_directories(${TBB_INCLUDE_DIRS})
-    link_directories(${TBB_LIBRARIES})
-    set(BDM_REQUIRED_LIBRARIES ${BDM_REQUIRED_LIBRARIES} ${TBB_LIBRARIES})
-  endif()
+find_package(TBB REQUIRED)
+if (TBB_FOUND)
+  include_directories(${TBB_INCLUDE_DIRS})
+  link_directories(${TBB_LIBRARIES})
+  set(BDM_REQUIRED_LIBRARIES ${BDM_REQUIRED_LIBRARIES} ${TBB_LIBRARIES})
 endif()
 
 find_package(ROOT REQUIRED COMPONENTS Geom Gui)

--- a/cmake/UseBioDynaMo.cmake.in
+++ b/cmake/UseBioDynaMo.cmake.in
@@ -129,11 +129,13 @@ if(paraview)
 endif()
 
 # paraview version 5.5 (MacOS) does not contain TBB
-find_package(TBB REQUIRED)
-if (TBB_FOUND)
-  include_directories(${TBB_INCLUDE_DIRS})
-  link_directories(${TBB_LIBRARIES})
-  set(BDM_REQUIRED_LIBRARIES ${BDM_REQUIRED_LIBRARIES} ${TBB_LIBRARIES})
+if (APPLE OR (NOT paraview OR NOT ${ParaView_FOUND}))
+  find_package(TBB REQUIRED)
+  if (TBB_FOUND)
+    include_directories(${TBB_INCLUDE_DIRS})
+    link_directories(${TBB_LIBRARIES})
+    set(BDM_REQUIRED_LIBRARIES ${BDM_REQUIRED_LIBRARIES} ${TBB_LIBRARIES})
+  endif()
 endif()
 
 find_package(ROOT REQUIRED COMPONENTS Geom Gui)

--- a/src/core/gpu/displacement_op_cuda_kernel.cu
+++ b/src/core/gpu/displacement_op_cuda_kernel.cu
@@ -210,10 +210,10 @@ bdm::DisplacementOpCudaKernel::DisplacementOpCudaKernel(uint32_t num_objects, ui
   GpuErrchk(cudaMalloc(&d_cell_movements_, 3 * num_objects * sizeof(double)));
 }
 
-void bdm::DisplacementOpCudaKernel::LaunchDisplacementKernel(double* positions,
-    double* diameters, double* tractor_force, double* adherence,
-    uint32_t* box_id, double* mass, double* timestep, double* max_displacement,
-    double* squared_radius, uint32_t* num_objects, uint32_t* starts,
+void bdm::DisplacementOpCudaKernel::LaunchDisplacementKernel(const double* positions,
+    const double* diameters, const double* tractor_force, const double* adherence,
+    uint32_t* box_id, const double* mass, const double* timestep, const double* max_displacement,
+    const double* squared_radius, uint32_t* num_objects, uint32_t* starts,
     uint16_t* lengths, uint32_t* successors, uint32_t* box_length,
     uint32_t* num_boxes_axis, int32_t* grid_dimensions,
     double* cell_movements) {

--- a/src/core/gpu/displacement_op_cuda_kernel.h
+++ b/src/core/gpu/displacement_op_cuda_kernel.h
@@ -27,9 +27,9 @@ class DisplacementOpCudaKernel {
   virtual ~DisplacementOpCudaKernel();
 
   void LaunchDisplacementKernel(
-      double* positions, double* diameter, double* tractor_force,
-      double* adherence, uint32_t* box_id, double* mass, double* timestep,
-      double* max_displacement, double* squared_radius, uint32_t* num_objects,
+      const double* positions, const double* diameter, const double* tractor_force,
+      const double* adherence, uint32_t* box_id, const double* mass, const double* timestep,
+      const double* max_displacement, const double* squared_radius, uint32_t* num_objects,
       uint32_t* starts, uint16_t* lengths, uint32_t* successors,
       uint32_t* box_length, uint32_t* num_boxes_axis, int32_t* grid_dimensions,
       double* cell_movements);

--- a/src/core/gpu/gpu_helper.h
+++ b/src/core/gpu/gpu_helper.h
@@ -54,10 +54,8 @@ static void FindGpuDevicesCuda() {
 
   cudaGetDeviceCount(&n_devices);
   if (n_devices == 0) {
-    Log::Error("FindGpuDevicesCuda",
-               "No CUDA-compatible GPU found on this machine! Switching to the "
-               "CPU version...");
-    param->use_gpu_ = false;
+    Log::Fatal("FindGpuDevicesCuda",
+               "No CUDA-compatible GPU found on this machine!");
     return;
   }
 
@@ -171,10 +169,8 @@ static void FindGpuDevicesOpenCL() {
     }
 
     if (devices->empty()) {
-      Log::Warning("FindGpuDevicesOpenCL",
-                   "No OpenCL-compatible GPU found on this machine! Switching "
-                   "to the CPU version...");
-      param->use_gpu_ = false;
+      Log::Fatal("FindGpuDevicesCuda",
+               "No CUDA-compatible GPU found on this machine!");
       return;
     }
 

--- a/src/core/gpu/gpu_helper.h
+++ b/src/core/gpu/gpu_helper.h
@@ -39,13 +39,6 @@
 
 namespace bdm {
 
-#ifdef USE_OPENCL
-static inline cl_int ClAssert(cl_int const code, char const* const file,
-                              int const line, bool const abort);
-static const char* GetErrorString(cl_int error);
-#define ClOk(err) ClAssert(err, __FILE__, __LINE__, true);
-#endif
-
 #ifdef USE_CUDA
 static void FindGpuDevicesCuda() {
   auto* param = Simulation::GetActive()->GetParam();
@@ -76,19 +69,51 @@ static void FindGpuDevicesCuda() {
 #endif
 
 #ifdef USE_OPENCL
+class OpenCLState {
+ public:
+  static OpenCLState* GetInstance() {
+    static OpenCLState kInstance;
+    return &kInstance;
+  }
+
+  /// Returns the OpenCL Context
+  cl::Context* GetOpenCLContext() { return &opencl_context_; }
+
+  /// Returns the OpenCL command queue
+  cl::CommandQueue* GetOpenCLCommandQueue() { return &opencl_command_queue_; }
+
+  /// Returns the OpenCL device (GPU) list
+  std::vector<cl::Device>* GetOpenCLDeviceList() { return &opencl_devices_; }
+
+  /// Returns the OpenCL program (kernel) list
+  std::vector<cl::Program>* GetOpenCLProgramList() { return &opencl_programs_; }
+
+ private:
+   cl::Context opencl_context_;             //!
+   cl::CommandQueue opencl_command_queue_;  //!
+   // Currently only support for one GPU device
+   std::vector<cl::Device> opencl_devices_;    //!
+   std::vector<cl::Program> opencl_programs_;  //!
+};
+
+static inline cl_int ClAssert(cl_int const code, char const* const file,
+                              int const line, bool const abort);
+static const char* GetErrorString(cl_int error);
+#define ClOk(err) ClAssert(err, __FILE__, __LINE__, true);
+
 static void CompileOpenCLKernels() {
   auto* sim = Simulation::GetActive();
-  auto* rm = sim->GetResourceManager();
   auto* param = sim->GetParam();
+  auto* ocl_state = OpenCLState::GetInstance();
 
-  std::vector<cl::Program>* all_programs = rm->GetOpenCLProgramList();
-  cl::Context* context = rm->GetOpenCLContext();
-  std::vector<cl::Device>* devices = rm->GetOpenCLDeviceList();
+  std::vector<cl::Program>* all_programs = ocl_state->GetOpenCLProgramList();
+  cl::Context* context = ocl_state->GetOpenCLContext();
+  std::vector<cl::Device>* devices = ocl_state->GetOpenCLDeviceList();
   // Compile OpenCL program for found device
   // TODO(ahmad): create more convenient way to compile all OpenCL kernels, by
   // going through a list of header files. Also, create a stringifier that goes
   // from .cl --> .h, since OpenCL kernels must be input as a string here
-  std::ifstream cl_file(BDM_SRC_DIR "/gpu/displacement_op_opencl_kernel.cl");
+  std::ifstream cl_file(BDM_SRC_DIR "/core/gpu/displacement_op_opencl_kernel.cl");
   if (cl_file.fail()) {
     Log::Error("CompileOpenCLKernels", "Kernel file does not exists!");
   }
@@ -127,12 +152,12 @@ static void FindGpuDevicesOpenCL() {
     // We keep the context and device list in the resource manager to be
     // accessible elsewhere to create command queues and buffers from
     auto* sim = Simulation::GetActive();
-    auto* rm = sim->GetResourceManager();
     auto* param = sim->GetParam();
+    auto* ocl_state = OpenCLState::GetInstance();
 
-    cl::Context* context = rm->GetOpenCLContext();
-    cl::CommandQueue* queue = rm->GetOpenCLCommandQueue();
-    std::vector<cl::Device>* devices = rm->GetOpenCLDeviceList();
+    cl::Context* context = ocl_state->GetOpenCLContext();
+    cl::CommandQueue* queue = ocl_state->GetOpenCLCommandQueue();
+    std::vector<cl::Device>* devices = ocl_state->GetOpenCLDeviceList();
 
     // Get list of OpenCL platforms.
     std::vector<cl::Platform> platform;
@@ -194,7 +219,7 @@ static void FindGpuDevicesOpenCL() {
     ClOk(queue_err);
 
     // Compile the OpenCL kernels
-    CompileOpenCLKernels<>();
+    CompileOpenCLKernels();
   } catch (const cl::Error& err) {
     Log::Error("FindGpuDevicesOpenCL", "OpenCL error: ", err.what(), "(",
                err.err(), ")");
@@ -206,7 +231,7 @@ static void InitializeGPUEnvironment() {
   auto* param = Simulation::GetActive()->GetParam();
   if (param->use_opencl_) {
 #ifdef USE_OPENCL
-    FindGpuDevicesOpenCL<>();
+    FindGpuDevicesOpenCL();
 #else
     Log::Fatal("InitializeGPUEnvironment",
                "You tried to use the GPU (OpenCL) version of BioDynaMo, but no "

--- a/src/core/grid.h
+++ b/src/core/grid.h
@@ -91,8 +91,9 @@ class CircularBuffer {
 /// A class that represents Cartesian 3D grid
 class Grid {
 // DisplacementOpCuda needs access to some Grid private members to reconstruct
-// the grid on GPU
+// the grid on GPU (same for DisplacementOpOpenCL)
 friend class DisplacementOpCuda;
+friend class DisplacementOpOpenCL;
 
  public:
   /// A single unit cube of the grid

--- a/src/core/grid.h
+++ b/src/core/grid.h
@@ -90,6 +90,10 @@ class CircularBuffer {
 
 /// A class that represents Cartesian 3D grid
 class Grid {
+// DisplacementOpCuda needs access to some Grid private members to reconstruct
+// the grid on GPU
+friend class DisplacementOpCuda;
+
  public:
   /// A single unit cube of the grid
   struct Box {

--- a/src/core/operation/displacement_op.h
+++ b/src/core/operation/displacement_op.h
@@ -54,11 +54,7 @@ class DisplacementOp {
     if (param->use_gpu_ && !force_cpu_implementation_) {
 #ifdef USE_OPENCL
       if (param->use_opencl_) {
-        auto* rm = Simulation::GetActive()->GetResourceManager();
-        rm->ApplyOnAllTypes(
-            [](auto* cells, uint16_t numa_node, uint16_t type_idx) {
-              opencl_(cells, numa_node_, type_idx);
-            });
+        opencl_();
       }
 #endif
 #ifdef USE_CUDA

--- a/src/core/operation/displacement_op.h
+++ b/src/core/operation/displacement_op.h
@@ -63,17 +63,9 @@ class DisplacementOp {
 #endif
 #ifdef USE_CUDA
       if (!param->use_opencl_) {
-        auto* rm = Simulation::GetActive()->GetResourceManager();
-        rm->ApplyOnAllTypes(
-            [](auto* cells, uint16_t numa_node, uint16_t type_idx) {
-              cuda_(cells, numa_node, type_idx);
-            });
+        cuda_();
       }
 #endif
-    } else {
-      Log::Fatal("DisplacementOp",
-                 "Currently GPU/FPGA implementation only supports spherical "
-                 "shapes.");
     }
   }
 

--- a/src/core/operation/displacement_op_cuda.h
+++ b/src/core/operation/displacement_op_cuda.h
@@ -114,8 +114,6 @@ class DisplacementOpCuda {
       lengths[i] = box.length_;	
       i++;
     }
-    // grid->GetSuccessors(&successors);
-    // grid->GetBoxInfo(&starts, &lengths);
     grid->GetGridInfo(&box_length, &num_boxes_axis, &grid_dimensions);
 
     // If this is the first time we perform physics on GPU using CUDA

--- a/src/core/operation/displacement_op_cuda.h
+++ b/src/core/operation/displacement_op_cuda.h
@@ -17,131 +17,176 @@
 #ifndef CORE_OPERATION_DISPLACEMENT_OP_CUDA_H_
 #define CORE_OPERATION_DISPLACEMENT_OP_CUDA_H_
 
-// #include <vector>
-//
-// #include "core/gpu/displacement_op_cuda_kernel.h"
-// #include "core/operation/bound_space_op.h"
-// #include "core/resource_manager.h"
-// #include "core/shape.h"
-// #include "core/simulation.h"
-// #include "core/util/log.h"
-// #include "core/util/type.h"
-//
-// namespace bdm {
-//
-// /// Defines the 3D physical interactions between physical objects
-// class DisplacementOpCuda {
-//  public:
-//   DisplacementOpCuda() {}
-//   ~DisplacementOpCuda() {}
-//
-//   template <typename TContainer>
-//   typename std::enable_if<is_soa_sphere<TContainer>::value>::type operator()(
-//       TContainer* cells, uint16_t numa_node, uint16_t type_idx) {
-//     auto* sim = Simulation::GetActive();
-//     auto* grid = sim->GetGrid();
-//     auto* param = sim->GetParam();
-//
-//     std::vector<Double3> cell_movements(cells->size());
-//     std::vector<double> mass(cells->size());
-//     std::vector<uint32_t> starts;
-//     std::vector<uint16_t> lengths;
-//     std::vector<uint32_t> successors(cells->size());
-//     uint32_t box_length;
-//     uint32_t num_objects = cells->size();
-//     std::array<uint32_t, 3> num_boxes_axis;
-//     std::array<int32_t, 3> grid_dimensions;
-//     double squared_radius =
-//         grid->GetLargestObjectSize() * grid->GetLargestObjectSize();
-//
-//     // We need to create a mass vector, because it is not stored by default
-//     in
-//     // a cell container
-//     cells->FillMassVector(&mass);
-//     grid->GetSuccessors(&successors);
-//     grid->GetBoxInfo(&starts, &lengths);
-//     grid->GetGridInfo(&box_length, &num_boxes_axis, &grid_dimensions);
-//
-//     // If this is the first time we perform physics on GPU using CUDA
-//     if (cdo_ == nullptr) {
-//       // Allocate 25% more memory so we don't need to reallocate GPU memory
-//       // for every (small) change
-//       uint32_t new_num_objects = static_cast<uint32_t>(1.25 * num_objects);
-//       uint32_t new_num_boxes = static_cast<uint32_t>(1.25 * starts.size());
-//
-//       // Store these extende buffer sizes for future reference
-//       num_objects_ = new_num_objects;
-//       num_boxes_ = new_num_boxes;
-//
-//       // Allocate required GPU memory
-//       cdo_ = new DisplacementOpCudaKernel(new_num_objects, new_num_boxes);
-//     } else {
-//       // If the number of simulation objects increased
-//       if (num_objects >= num_objects_) {
-//         Log::Info("DisplacementOpCuda",
-//                   "\nThe number of cells increased signficantly (from ",
-//                   num_objects_, " to ", num_objects,
-//                   "), so we allocate bigger GPU buffers\n");
-//         uint32_t new_num_objects = static_cast<uint32_t>(1.25 * num_objects);
-//         num_objects_ = new_num_objects;
-//         cdo_->ResizeCellBuffers(new_num_objects);
-//       }
-//
-//       // If the neighbor grid size increased
-//       if (starts.size() >= num_boxes_) {
-//         Log::Info("DisplacementOpCuda",
-//                   "\nThe number of boxes increased signficantly (from ",
-//                   num_boxes_, " to ", "), so we allocate bigger GPU
-//                   buffers\n");
-//         uint32_t new_num_boxes = static_cast<uint32_t>(1.25 * starts.size());
-//         num_boxes_ = new_num_boxes;
-//         cdo_->ResizeGridBuffers(new_num_boxes);
-//       }
-//     }
-//
-//     cdo_->LaunchDisplacementKernel(
-//         cells->GetPositionPtr(), cells->GetDiameterPtr(),
-//         cells->GetTractorForcePtr(), cells->GetAdherencePtr(),
-//         cells->GetBoxIdPtr(), mass.data(), &(param->simulation_time_step_),
-//         &(param->simulation_max_displacement_), &squared_radius,
-//         &num_objects,
-//         starts.data(), lengths.data(), successors.data(), &box_length,
-//         num_boxes_axis.data(), grid_dimensions.data(),
-//         cell_movements.data()->data());
-//
-// // set new positions after all updates have been calculated
-// // otherwise some cells would see neighbors with already updated positions
-// // which would lead to inconsistencies
-// #pragma omp parallel for
-//     for (size_t i = 0; i < cells->size(); i++) {
-//       auto&& cell = (*cells)[i];
-//       cell.UpdatePosition(cell_movements[i]);
-//       if (param->bound_space_) {
-//         ApplyBoundingBox(&cell, param->min_bound_, param->max_bound_);
-//       }
-//       cell.SetPosition(cell.GetPosition());
-//
-//       // Reset biological movement to 0.
-//       cell.SetTractorForce({0, 0, 0});
-//     }
-//   }
-//
-//   template <typename TContainer>
-//   typename std::enable_if<!is_soa_sphere<TContainer>::value>::type
-//   operator()(
-//       TContainer* cells, uint16_t numa_node, uint16_t type_idx) {
-//     Fatal("DisplacementOpCuda",
-//           "You tried to compile GPU-specific function calls for a non-SOA
-//           data "
-//           "structure or non-spherical simulation object.");
-//   }
-//
-//  private:
-//   DisplacementOpCudaKernel* cdo_ = nullptr;
-//   uint32_t num_boxes_ = 0;
-//   uint32_t num_objects_ = 0;
-// };
-//
-// }  // namespace bdm
+#include <vector>
+
+#include "core/gpu/displacement_op_cuda_kernel.h"
+#include "core/operation/bound_space_op.h"
+#include "core/resource_manager.h"
+#include "core/shape.h"
+#include "core/sim_object/cell.h"
+#include "core/simulation.h"
+#include "core/util/log.h"
+#include "core/util/thread_info.h"
+#include "core/util/type.h"
+
+namespace bdm {
+
+
+/// Defines the 3D physical interactions between physical objects
+class DisplacementOpCuda {
+ public:
+  DisplacementOpCuda() {}
+  ~DisplacementOpCuda() {}
+
+  void IsNonSphericalObjectPresent(const SimObject* so, bool* answer) {
+    if (so->GetShape() != Shape::kSphere) {
+      *answer = true;
+    }
+  }
+
+  void operator()() {
+    auto* sim = Simulation::GetActive();
+    auto* grid = sim->GetGrid();
+    auto* param = sim->GetParam();
+    auto* rm = sim->GetResourceManager();
+
+    // Check the number of NUMA domains on the system. Currently only 1 is
+    // supported for GPU execution.
+    if (ThreadInfo::GetInstance()->GetNumaNodes() > 1) {
+      Log::Fatal("DisplacementOpCuda",
+                "\nThe GPU execution only supports systems with 1 NUMA domain.");
+      return;
+    }
+
+    uint32_t num_objects = rm->GetNumSimObjects();
+
+    // Cannot use Double3 here, because the `data()` function returns a const
+    // pointer to the underlying array, whereas the CUDA kernal will cast it to
+    // a void pointer. The conversion of `const double *` to `void *` is illegal.
+    std::vector<std::array<double, 3>> cell_movements(num_objects);
+    std::vector<Double3> cell_positions(num_objects);
+    std::vector<double> cell_diameters(num_objects);
+    std::vector<double> cell_adherence(num_objects);
+    std::vector<Double3> cell_tractor_force(num_objects);
+    std::vector<uint32_t> cell_boxid(num_objects);
+    std::vector<double> mass(num_objects);
+    std::vector<uint32_t> starts;
+    std::vector<uint16_t> lengths;
+    std::vector<uint32_t> successors(num_objects);
+    uint32_t box_length;
+    std::array<uint32_t, 3> num_boxes_axis;
+    std::array<int32_t, 3> grid_dimensions;
+    double squared_radius =
+        grid->GetLargestObjectSize() * grid->GetLargestObjectSize();
+
+    bool is_non_spherical_object = false;
+
+    rm->ApplyOnAllElements([&](SimObject* so, SoHandle soh) {
+      // Check if there are any non-spherical objects in our simulation, because
+      // GPU accelerations currently supports only sphere-sphere interactions
+      IsNonSphericalObjectPresent(so, &is_non_spherical_object);
+      if (is_non_spherical_object) {
+        Log::Fatal("DisplacementOpCuda",
+                 "\nWe detected a non-spherical object during the GPU execution. This is currently not supported.");
+        return;
+      }
+      auto* cell = bdm_static_cast<Cell*>(so);
+      auto idx = soh.GetElementIdx();
+      mass[idx] = cell->GetMass();
+      cell_diameters[idx] = cell->GetDiameter();
+      cell_adherence[idx] = cell->GetAdherence();
+      cell_tractor_force[idx] = cell->GetTractorForce();
+      cell_positions[idx] = cell->GetPosition();
+      cell_boxid[idx] = cell->GetBoxIdx();
+    });
+
+    uint16_t numa_node = 0; // GPU code only supports 1 NUMA domain currently
+    for (size_t i = 0; i < grid->successors_.size(numa_node); i++) {	
+      auto sh = SoHandle(numa_node, i);	
+      successors[i] = grid->successors_[sh].GetElementIdx();	
+    }
+
+    starts.resize(grid->boxes_.size());
+    lengths.resize(grid->boxes_.size());
+    size_t i = 0;
+    for (auto& box : grid->boxes_) {
+      starts[i] = box.start_.load().GetElementIdx();	
+      lengths[i] = box.length_;	
+      i++;
+    }
+    // grid->GetSuccessors(&successors);
+    // grid->GetBoxInfo(&starts, &lengths);
+    grid->GetGridInfo(&box_length, &num_boxes_axis, &grid_dimensions);
+
+    // If this is the first time we perform physics on GPU using CUDA
+    if (cdo_ == nullptr) {
+      // Allocate 25% more memory so we don't need to reallocate GPU memory
+      // for every (small) change
+      uint32_t new_num_objects = static_cast<uint32_t>(1.25 * num_objects);
+      uint32_t new_num_boxes = static_cast<uint32_t>(1.25 * starts.size());
+
+      // Store these extended buffer sizes for future reference
+      num_objects_ = new_num_objects;
+      num_boxes_ = new_num_boxes;
+
+      // Allocate required GPU memory
+      cdo_ = new DisplacementOpCudaKernel(new_num_objects, new_num_boxes);
+    } else {
+      // If the number of simulation objects increased
+      if (num_objects >= num_objects_) {
+        Log::Info("DisplacementOpCuda",
+                  "\nThe number of cells increased signficantly (from ",
+                  num_objects_, " to ", num_objects,
+                  "), so we allocate bigger GPU buffers\n");
+        uint32_t new_num_objects = static_cast<uint32_t>(1.25 * num_objects);
+        num_objects_ = new_num_objects;
+        cdo_->ResizeCellBuffers(new_num_objects);
+      }
+
+      // If the neighbor grid size increased
+      if (starts.size() >= num_boxes_) {
+        Log::Info("DisplacementOpCuda",
+                  "\nThe number of boxes increased signficantly (from ",
+                  num_boxes_, " to ", "), so we allocate bigger GPU buffers\n");
+        uint32_t new_num_boxes = static_cast<uint32_t>(1.25 * starts.size());
+        num_boxes_ = new_num_boxes;
+        cdo_->ResizeGridBuffers(new_num_boxes);
+      }
+    }
+
+    cdo_->LaunchDisplacementKernel(
+        cell_positions.data()->data(), cell_diameters.data(),
+        cell_tractor_force.data()->data(), cell_adherence.data(),
+        cell_boxid.data(), mass.data(), &(param->simulation_time_step_),
+        &(param->simulation_max_displacement_), &squared_radius,
+        &num_objects,
+        starts.data(), lengths.data(), successors.data(), &box_length,
+        num_boxes_axis.data(), grid_dimensions.data(),
+        cell_movements.data()->data());
+
+// set new positions after all updates have been calculated
+// otherwise some cells would see neighbors with already updated positions
+// which would lead to inconsistencies
+    rm->ApplyOnAllElements([&](SimObject* so, SoHandle soh) {
+      auto* cell = dynamic_cast<Cell*>(so);
+      auto idx = soh.GetElementIdx();
+      Double3 new_pos;
+      new_pos[0] = cell_movements[idx][0];
+      new_pos[1] = cell_movements[idx][1];
+      new_pos[2] = cell_movements[idx][2];
+      cell->UpdatePosition(new_pos);
+      if (param->bound_space_) {
+        ApplyBoundingBox(so, param->min_bound_, param->max_bound_);
+      }
+    });
+  }
+
+ private:
+  DisplacementOpCudaKernel* cdo_ = nullptr;
+  uint32_t num_boxes_ = 0;
+  uint32_t num_objects_ = 0;
+};
+
+}  // namespace bdm
 
 #endif  // CORE_OPERATION_DISPLACEMENT_OP_CUDA_H_

--- a/src/core/operation/displacement_op_opencl.h
+++ b/src/core/operation/displacement_op_opencl.h
@@ -1,22 +1,21 @@
-// //
 // -----------------------------------------------------------------------------
-// //
-// // Copyright (C) The BioDynaMo Project.
-// // All Rights Reserved.
-// //
-// // Licensed under the Apache License, Version 2.0 (the "License");
-// // you may not use this file except in compliance with the License.
-// //
-// // See the LICENSE file distributed with this work for details.
-// // See the NOTICE file distributed with this work for additional information
-// // regarding copyright ownership.
-// //
-// //
+//
+// Copyright (C) The BioDynaMo Project.
+// All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// See the LICENSE file distributed with this work for details.
+// See the NOTICE file distributed with this work for additional information
+// regarding copyright ownership.
+//
 // -----------------------------------------------------------------------------
 
 #ifndef CORE_OPERATION_DISPLACEMENT_OP_OPENCL_H_
 #define CORE_OPERATION_DISPLACEMENT_OP_OPENCL_H_
 
+#if defined(USE_OPENCL) && !defined(__ROOTCLING__)
 #include <vector>
 
 #include "core/gpu/gpu_helper.h"
@@ -232,5 +231,7 @@ class DisplacementOpOpenCL {
 };
 
 }  // namespace bdm
+
+#endif  // defined(USE_OPENCL) && !defined(__ROOTCLING__)
 
 #endif  // CORE_OPERATION_DISPLACEMENT_OP_OPENCL_H_

--- a/src/core/operation/displacement_op_opencl.h
+++ b/src/core/operation/displacement_op_opencl.h
@@ -17,190 +17,220 @@
 #ifndef CORE_OPERATION_DISPLACEMENT_OP_OPENCL_H_
 #define CORE_OPERATION_DISPLACEMENT_OP_OPENCL_H_
 
-// #include <vector>
-//
-// #ifdef USE_OPENCL
-// #define __CL_ENABLE_EXCEPTIONS
-// #ifdef __APPLE__
-// #include <OpenCL/cl.hpp>
-// #else
-// #include <CL/cl.hpp>
-// #endif
-// #endif
-//
-// #include "core/gpu/gpu_helper.h"
-// #include "core/grid.h"
-// #include "core/operation/bound_space_op.h"
-// #include "core/resource_manager.h"
-// #include "core/shape.h"
-// #include "core/util/type.h"
-//
-// namespace bdm {
-//
-// /// Defines the 3D physical interactions between physical objects
-// class DisplacementOpOpenCL {
-//  public:
-//   DisplacementOpOpenCL() {}
-//   ~DisplacementOpOpenCL() {}
-//
-//   template <typename TContainer>
-//   typename std::enable_if<is_soa_sphere<TContainer>::value>::type operator()(
-//       TContainer* cells, uint16_t numa_node, uint16_t type_idx) const {
-// #ifdef USE_OPENCL
-//     auto* sim = Simulation::GetActive();
-//     auto* grid = sim->GetGrid();
-//     auto* rm = sim->GetResourceManager();
-//     auto* param = sim->GetParam();
-//
-//     auto context = rm->GetOpenCLContext();
-//     auto queue = rm->GetOpenCLCommandQueue();
-//     auto programs = rm->GetOpenCLProgramList();
-//
-//     std::vector<cl_double> mass(cells->size());
-//     std::vector<std::array<cl_double, 3>> cell_movements(cells->size());
-//     std::vector<cl_uint> gpu_starts;
-//     std::vector<cl_ushort> gpu_lengths;
-//     std::vector<cl_uint> successors(cells->size());
-//     cl_uint box_length;
-//     std::array<cl_uint, 3> num_boxes_axis;
-//     std::array<cl_int, 3> grid_dimensions;
-//     cl_double squared_radius =
-//         grid->GetLargestObjectSize() * grid->GetLargestObjectSize();
-//
-//     // We need to create a mass vector, because it is not stored by default
-//     in
-//     // a cell container
-//     cells->FillMassVector(&mass);
-//     grid->GetSuccessors(&successors);
-//     grid->GetBoxInfo(&gpu_starts, &gpu_lengths);
-//     grid->GetGridInfo(&box_length, &num_boxes_axis, &grid_dimensions);
-//
-//     // Allocate GPU buffers
-//     cl::Buffer positions_arg(*context, CL_MEM_READ_ONLY |
-//     CL_MEM_USE_HOST_PTR,
-//                              cells->size() * 3 * sizeof(cl_double),
-//                              cells->GetPositionPtr());
-//     cl::Buffer diameters_arg(*context, CL_MEM_READ_ONLY |
-//     CL_MEM_USE_HOST_PTR,
-//                              cells->size() * sizeof(cl_double),
-//                              cells->GetDiameterPtr());
-//     cl::Buffer tractor_force_arg(
-//         *context, CL_MEM_READ_ONLY | CL_MEM_USE_HOST_PTR,
-//         cells->size() * 3 * sizeof(cl_double), cells->GetTractorForcePtr());
-//     cl::Buffer adherence_arg(*context, CL_MEM_READ_ONLY |
-//     CL_MEM_USE_HOST_PTR,
-//                              cells->size() * sizeof(cl_double),
-//                              cells->GetAdherencePtr());
-//     cl::Buffer box_id_arg(*context, CL_MEM_READ_ONLY | CL_MEM_USE_HOST_PTR,
-//                           cells->size() * sizeof(cl_uint),
-//                           cells->GetBoxIdPtr());
-//     cl::Buffer mass_arg(*context, CL_MEM_READ_ONLY | CL_MEM_USE_HOST_PTR,
-//                         cells->size() * sizeof(cl_double), mass.data());
-//     cl::Buffer cell_movements_arg(
-//         *context, CL_MEM_READ_WRITE | CL_MEM_USE_HOST_PTR,
-//         cells->size() * 3 * sizeof(cl_double),
-//         cell_movements.data()->data());
-//     cl::Buffer starts_arg(*context, CL_MEM_READ_ONLY | CL_MEM_USE_HOST_PTR,
-//                           gpu_starts.size() * sizeof(cl_uint),
-//                           gpu_starts.data());
-//     cl::Buffer lengths_arg(*context, CL_MEM_READ_ONLY | CL_MEM_USE_HOST_PTR,
-//                            gpu_lengths.size() * sizeof(cl_short),
-//                            gpu_lengths.data());
-//     cl::Buffer successors_arg(*context, CL_MEM_READ_ONLY |
-//     CL_MEM_USE_HOST_PTR,
-//                               successors.size() * sizeof(cl_uint),
-//                               successors.data());
-//     cl::Buffer nba_arg(*context, CL_MEM_READ_ONLY | CL_MEM_USE_HOST_PTR,
-//                        3 * sizeof(cl_uint), num_boxes_axis.data());
-//     cl::Buffer gd_arg(*context, CL_MEM_READ_ONLY | CL_MEM_USE_HOST_PTR,
-//                       3 * sizeof(cl_int), grid_dimensions.data());
-//
-//     // Create the kernel object from our program
-//     // TODO(ahmad): generalize the program selection, in case we have more
-//     than
-//     // one. We can maintain an unordered map of programs maybe
-//     cl::Kernel collide((*programs)[0], "collide");
-//
-//     // Set kernel parameters
-//     collide.setArg(0, positions_arg);
-//     collide.setArg(1, diameters_arg);
-//     collide.setArg(2, tractor_force_arg);
-//     collide.setArg(3, adherence_arg);
-//     collide.setArg(4, box_id_arg);
-//     collide.setArg(5, mass_arg);
-//     collide.setArg(6, param->simulation_time_step_);
-//     collide.setArg(7, param->simulation_max_displacement_);
-//     collide.setArg(8, squared_radius);
-//
-//     collide.setArg(9, static_cast<cl_int>(cells->size()));
-//     collide.setArg(10, starts_arg);
-//     collide.setArg(11, lengths_arg);
-//     collide.setArg(12, successors_arg);
-//     collide.setArg(13, box_length);
-//     collide.setArg(14, nba_arg);
-//     collide.setArg(15, gd_arg);
-//     collide.setArg(16, cell_movements_arg);
-//
-//     // The amount of threads for each work group (analogous to CUDA thread
-//     // block)
-//     int block_size = 256;
-//
-//     auto num_objects = cells->size();
-//
-//     try {
-//       // The global size determines the total number of threads that will be
-//       // spawned on the GPU, in groups of local_size
-//       cl::NDRange global_size =
-//           cl::NDRange(num_objects + (block_size - (num_objects %
-//           block_size)));
-//       cl::NDRange local_size = cl::NDRange(block_size);
-//       queue->enqueueNDRangeKernel(collide, cl::NullRange, global_size,
-//                                   local_size);
-//     } catch (const cl::Error& err) {
-//       Log::Error("DisplacementOpOpenCL", err.what(), "(", err.err(), ") = ",
-//                  GetErrorString(err.err()));
-//       throw;
-//     }
-//
-//     try {
-//       queue->enqueueReadBuffer(cell_movements_arg, CL_TRUE, 0,
-//                                cells->size() * 3 * sizeof(cl_double),
-//                                cell_movements.data()->data());
-//     } catch (const cl::Error& err) {
-//       Log::Error("DisplacementOpOpenCL", err.what(), "(", err.err(), ") = ",
-//                  GetErrorString(err.err()));
-//       throw;
-//     }
-//
-// // set new positions after all updates have been calculated
-// // otherwise some cells would see neighbors with already updated positions
-// // which would lead to inconsistencies
-// #pragma omp parallel for
-//     for (size_t i = 0; i < cells->size(); i++) {
-//       auto&& cell = (*cells)[i];
-//       cell.UpdatePosition(cell_movements[i]);
-//       if (param->bound_space_) {
-//         ApplyBoundingBox(&cell, param->min_bound_, param->max_bound_);
-//       }
-//       cell.SetPosition(cell.GetPosition());
-//
-//       // Reset biological movement to 0.
-//       cell.SetTractorForce({0, 0, 0});
-//     }
-// #endif
-//   }
-//
-//   template <typename TContainer>
-//   typename std::enable_if<!is_soa_sphere<TContainer>::value>::type
-//   operator()(
-//       TContainer* cells, uint16_t numa_node, uint16_t type_idx) {
-//     Fatal("DisplacementOpCuda",
-//           "You tried to compile GPU-specific function calls for a non-SOA
-//           data "
-//           "structure or non-spherical simulation object.");
-//   }
-// };
-//
-// }  // namespace bdm
+#include <vector>
+
+#include "core/gpu/gpu_helper.h"
+#include "core/grid.h"
+#include "core/operation/bound_space_op.h"
+#include "core/shape.h"
+#include "core/util/thread_info.h"
+#include "core/util/type.h"
+
+namespace bdm {
+
+/// Defines the 3D physical interactions between physical objects
+class DisplacementOpOpenCL {
+ public:
+  DisplacementOpOpenCL() {}
+  ~DisplacementOpOpenCL() {}
+
+  void IsNonSphericalObjectPresent(const SimObject* so, bool* answer) {
+    if (so->GetShape() != Shape::kSphere) {
+      *answer = true;
+    }
+  }
+
+  void operator()() {
+    auto* sim = Simulation::GetActive();
+    auto* grid = sim->GetGrid();
+    auto* param = sim->GetParam();
+    auto* rm = sim->GetResourceManager();
+
+    // Check the number of NUMA domains on the system. Currently only 1 is
+    // supported for GPU execution.
+    if (ThreadInfo::GetInstance()->GetNumaNodes() > 1) {
+      Log::Fatal("DisplacementOpOpenCL",
+                "\nThe GPU execution only supports systems with 1 NUMA domain.");
+      return;
+    }
+
+    uint32_t num_objects = rm->GetNumSimObjects();
+
+    auto* ocl_state = OpenCLState::GetInstance();
+    auto context = ocl_state->GetOpenCLContext();
+    auto queue = ocl_state->GetOpenCLCommandQueue();
+    auto programs = ocl_state->GetOpenCLProgramList();
+
+    // Cannot use Double3 here, because the `data()` function returns a const
+    // pointer to the underlying array, whereas the CUDA kernal will cast it to
+    // a void pointer. The conversion of `const double *` to `void *` is illegal.
+    std::vector<std::array<cl_double, 3>> cell_movements(num_objects);
+    std::vector<std::array<cl_double, 3>> cell_positions(num_objects);
+    std::vector<cl_double> cell_diameters(num_objects);
+    std::vector<cl_double> cell_adherence(num_objects);
+    std::vector<std::array<cl_double, 3>> cell_tractor_force(num_objects);
+    std::vector<cl_uint> cell_boxid(num_objects);
+    std::vector<cl_double> mass(num_objects);
+    std::vector<cl_uint> starts;
+    std::vector<cl_ushort> lengths;
+    std::vector<cl_uint> successors(num_objects);
+    cl_uint box_length;
+    std::array<cl_uint, 3> num_boxes_axis;
+    std::array<cl_int, 3> grid_dimensions;
+    cl_double squared_radius =
+        grid->GetLargestObjectSize() * grid->GetLargestObjectSize();
+
+    bool is_non_spherical_object = false;
+
+    rm->ApplyOnAllElements([&](SimObject* so, SoHandle soh) {
+      // Check if there are any non-spherical objects in our simulation, because
+      // GPU accelerations currently supports only sphere-sphere interactions
+      IsNonSphericalObjectPresent(so, &is_non_spherical_object);
+      if (is_non_spherical_object) {
+        Log::Fatal("DisplacementOpOpenCL",
+                 "\nWe detected a non-spherical object during the GPU execution. This is currently not supported.");
+        return;
+      }
+      auto* cell = bdm_static_cast<Cell*>(so);
+      auto idx = soh.GetElementIdx();
+      mass[idx] = cell->GetMass();
+      cell_diameters[idx] = cell->GetDiameter();
+      cell_adherence[idx] = cell->GetAdherence();
+      cell_boxid[idx] = cell->GetBoxIdx();
+      cell_tractor_force[idx][0] = cell->GetTractorForce()[0];
+      cell_tractor_force[idx][1] = cell->GetTractorForce()[1];
+      cell_tractor_force[idx][2] = cell->GetTractorForce()[2];
+      cell_positions[idx][0] = cell->GetPosition()[0];
+      cell_positions[idx][1] = cell->GetPosition()[1];
+      cell_positions[idx][2] = cell->GetPosition()[2];
+    });
+
+    uint16_t numa_node = 0; // GPU code only supports 1 NUMA domain currently
+    for (size_t i = 0; i < grid->successors_.size(numa_node); i++) {	
+      auto sh = SoHandle(numa_node, i);	
+      successors[i] = grid->successors_[sh].GetElementIdx();	
+    }
+
+    starts.resize(grid->boxes_.size());
+    lengths.resize(grid->boxes_.size());
+    size_t i = 0;
+    for (auto& box : grid->boxes_) {
+      starts[i] = box.start_.load().GetElementIdx();	
+      lengths[i] = box.length_;	
+      i++;
+    }
+    grid->GetGridInfo(&box_length, &num_boxes_axis, &grid_dimensions);
+
+    // Allocate GPU buffers
+    cl::Buffer positions_arg(*context, CL_MEM_READ_ONLY |
+    CL_MEM_USE_HOST_PTR,
+                             num_objects * 3 * sizeof(cl_double),
+                             cell_positions.data()->data());
+    cl::Buffer diameters_arg(*context, CL_MEM_READ_ONLY |
+    CL_MEM_USE_HOST_PTR,
+                             num_objects * sizeof(cl_double),
+                             cell_diameters.data());
+    cl::Buffer tractor_force_arg(
+        *context, CL_MEM_READ_ONLY | CL_MEM_USE_HOST_PTR,
+        num_objects * 3 * sizeof(cl_double), cell_tractor_force.data()->data());
+    cl::Buffer adherence_arg(*context, CL_MEM_READ_ONLY |
+    CL_MEM_USE_HOST_PTR,
+                             num_objects * sizeof(cl_double),
+                             cell_adherence.data());
+    cl::Buffer box_id_arg(*context, CL_MEM_READ_ONLY | CL_MEM_USE_HOST_PTR,
+                          num_objects * sizeof(cl_uint), cell_boxid.data());
+    cl::Buffer mass_arg(*context, CL_MEM_READ_ONLY | CL_MEM_USE_HOST_PTR,
+                        num_objects * sizeof(cl_double), mass.data());
+    cl::Buffer cell_movements_arg(
+        *context, CL_MEM_READ_WRITE | CL_MEM_USE_HOST_PTR,
+        num_objects * 3 * sizeof(cl_double),
+        cell_movements.data()->data());
+    cl::Buffer starts_arg(*context, CL_MEM_READ_ONLY | CL_MEM_USE_HOST_PTR,
+                          starts.size() * sizeof(cl_uint),
+                          starts.data());
+    cl::Buffer lengths_arg(*context, CL_MEM_READ_ONLY | CL_MEM_USE_HOST_PTR,
+                           lengths.size() * sizeof(cl_short),
+                           lengths.data());
+    cl::Buffer successors_arg(*context, CL_MEM_READ_ONLY |
+    CL_MEM_USE_HOST_PTR,
+                              successors.size() * sizeof(cl_uint),
+                              successors.data());
+    cl::Buffer nba_arg(*context, CL_MEM_READ_ONLY | CL_MEM_USE_HOST_PTR,
+                       3 * sizeof(cl_uint), num_boxes_axis.data());
+    cl::Buffer gd_arg(*context, CL_MEM_READ_ONLY | CL_MEM_USE_HOST_PTR,
+                      3 * sizeof(cl_int), grid_dimensions.data());
+
+    // Create the kernel object from our program
+    // TODO(ahmad): generalize the program selection, in case we have more than
+    // one. We can maintain an unordered map of programs maybe
+    cl::Kernel collide((*programs)[0], "collide");
+
+    // Set kernel parameters
+    collide.setArg(0, positions_arg);
+    collide.setArg(1, diameters_arg);
+    collide.setArg(2, tractor_force_arg);
+    collide.setArg(3, adherence_arg);
+    collide.setArg(4, box_id_arg);
+    collide.setArg(5, mass_arg);
+    collide.setArg(6, param->simulation_time_step_);
+    collide.setArg(7, param->simulation_max_displacement_);
+    collide.setArg(8, squared_radius);
+
+    collide.setArg(9, static_cast<cl_int>(num_objects));
+    collide.setArg(10, starts_arg);
+    collide.setArg(11, lengths_arg);
+    collide.setArg(12, successors_arg);
+    collide.setArg(13, box_length);
+    collide.setArg(14, nba_arg);
+    collide.setArg(15, gd_arg);
+    collide.setArg(16, cell_movements_arg);
+
+    // The amount of threads for each work group (similar to CUDA thread block)
+    int block_size = 256;
+
+    try {
+      // The global size determines the total number of threads that will be
+      // spawned on the GPU, in groups of local_size
+      cl::NDRange global_size =
+          cl::NDRange(num_objects + (block_size - (num_objects %
+          block_size)));
+      cl::NDRange local_size = cl::NDRange(block_size);
+      queue->enqueueNDRangeKernel(collide, cl::NullRange, global_size,
+                                  local_size);
+    } catch (const cl::Error& err) {
+      Log::Error("DisplacementOpOpenCL", err.what(), "(", err.err(), ") = ",
+                 GetErrorString(err.err()));
+      throw;
+    }
+
+    try {
+      queue->enqueueReadBuffer(cell_movements_arg, CL_TRUE, 0,
+                               num_objects * 3 * sizeof(cl_double),
+                               cell_movements.data()->data());
+    } catch (const cl::Error& err) {
+      Log::Error("DisplacementOpOpenCL", err.what(), "(", err.err(), ") = ",
+                 GetErrorString(err.err()));
+      throw;
+    }
+
+// set new positions after all updates have been calculated
+// otherwise some cells would see neighbors with already updated positions
+// which would lead to inconsistencies
+    rm->ApplyOnAllElements([&](SimObject* so, SoHandle soh) {
+      auto* cell = dynamic_cast<Cell*>(so);
+      auto idx = soh.GetElementIdx();
+      Double3 new_pos;
+      new_pos[0] = cell_movements[idx][0];
+      new_pos[1] = cell_movements[idx][1];
+      new_pos[2] = cell_movements[idx][2];
+      cell->UpdatePosition(new_pos);
+      if (param->bound_space_) {
+        ApplyBoundingBox(so, param->min_bound_, param->max_bound_);
+      }
+    });
+  }
+};
+
+}  // namespace bdm
 
 #endif  // CORE_OPERATION_DISPLACEMENT_OP_OPENCL_H_

--- a/src/core/resource_manager.h
+++ b/src/core/resource_manager.h
@@ -391,29 +391,15 @@ class ResourceManager {
   }
 
  protected:
-#ifdef USE_OPENCL
-  cl::Context* GetOpenCLContext() { return &opencl_context_; }
-  cl::CommandQueue* GetOpenCLCommandQueue() { return &opencl_command_queue_; }
-  std::vector<cl::Device>* GetOpenCLDeviceList() { return &opencl_devices_; }
-  std::vector<cl::Program>* GetOpenCLProgramList() { return &opencl_programs_; }
-#endif
 
   /// Maps an SoUid to its storage location in `sim_objects_` \n
   tbb::concurrent_unordered_map<SoUid, SoHandle> uid_soh_map_;  //!
-  ///
+  /// Pointer container for all simulation objects
   std::vector<std::vector<SimObject*>> sim_objects_;
-
+  /// Maps a diffusion grid ID to the pointer to the diffusion grid
   std::unordered_map<uint64_t, DiffusionGrid*> diffusion_grids_;
 
   ThreadInfo* thread_info_ = ThreadInfo::GetInstance();  //!
-
-#ifdef USE_OPENCL
-  cl::Context opencl_context_;             //!
-  cl::CommandQueue opencl_command_queue_;  //!
-  // Currently only support for one GPU device
-  std::vector<cl::Device> opencl_devices_;    //!
-  std::vector<cl::Program> opencl_programs_;  //!
-#endif
 
   friend class SimulationBackup;
   BDM_CLASS_DEF_NV(ResourceManager, 1);

--- a/test/system/cell_division_gpu/src/cell_division_gpu.h
+++ b/test/system/cell_division_gpu/src/cell_division_gpu.h
@@ -45,11 +45,13 @@ inline void ExpectArrayNear(const Double3& actual, const Double3& expected,
 enum ExecutionMode { kCpu, kCuda, kOpenCl };
 
 inline void RunTest(bool* result, ExecutionMode mode) {
+  std::cout << "Running test case " << mode << std::endl;
   auto set_param = [&](auto* param) {
     switch (mode) {
       case kCpu:
         break;
       case kOpenCl:
+        param->use_gpu_ = true;
         param->use_opencl_ = true;
       case kCuda:
         param->use_gpu_ = true;
@@ -58,7 +60,6 @@ inline void RunTest(bool* result, ExecutionMode mode) {
 
   Simulation simulation("cell_division_gpu", set_param);
   auto* rm = simulation.GetResourceManager();
-  auto* param = simulation.GetParam();
   rm->Clear();
 
 // We need to give every test the same seed for the RNG, because in the cell

--- a/test/unit/core/operation/displacement_op_gpu_test.cc
+++ b/test/unit/core/operation/displacement_op_gpu_test.cc
@@ -23,12 +23,17 @@
 namespace bdm {
 namespace displacement_op_gpu_test_internal {
 
+// NB: The GPU execution 'context' for the displacement operation differes,
+// from the CPU version. Once the CPU version supports the same execution
+// context, we can include it for direct comparison of results.
+
 enum ExecutionMode { kCuda, kOpenCl };
 
 void RunTest(ExecutionMode mode) {
   auto set_param = [&](Param* param) {
     switch (mode) {
       case kOpenCl:
+        param->use_gpu_ = true;
         param->use_opencl_ = true;
       case kCuda:
         param->use_gpu_ = true;
@@ -118,6 +123,7 @@ void RunTest2(ExecutionMode mode) {
   auto set_param = [&](auto* param) {
     switch (mode) {
       case kOpenCl:
+        param->use_gpu_ = true;
         param->use_opencl_ = true;
       case kCuda:
         param->use_gpu_ = true;
@@ -149,7 +155,7 @@ void RunTest2(ExecutionMode mode) {
   grid->ClearGrid();
   grid->Initialize();
 
-  // execute operation
+  // execute operation on all cells
   DisplacementOp op;
   op();
 


### PR DESCRIPTION
The GPU code is refactored to be compatible with the dynamic runtime of BioDynaMo. At the moment there are two restrictions:

1. Only 1 NUMA domain is supported. We throw a fatal error when we detect more than 1 NUMA domain.
2. Only sphere-sphere interactions are supported. We throw a fatal error when we detect a non-spherical object in the simulation.

Since the dynamic runtime does not have the state of simulation objects in contiguous arrays (SoA layout), we perform a copy operations prior to dispatching the kernel to the GPU such we again have a contiguous array layout.