### PR TITLE
Fix numa issue on systems without libnuma support

### DIFF
--- a/src/core/util/numa.h
+++ b/src/core/util/numa.h
@@ -30,6 +30,7 @@ inline int numa_run_on_node(int) { return 0; }
 inline int numa_node_of_cpu(int) { return 0; }
 inline int numa_move_pages(int pid, unsigned long count, void **pages,
                            const int *nodes, int *status, int flags) {
+  *status = 0;
   return 0;
 }
 


### PR DESCRIPTION
On systems without libnuma support we store data on the lowest NUMA domain. Therefore, the value of `status` in `numa_move_pages` should be set to zero.