### PR TITLE
Update travis failure output command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,6 @@ matrix:
 script:
   - shell_session_update() { :; };
   - $SCRIPT
-  - exit 1;
 
 services:
   - docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,8 @@ notifications:
   slack: cernopenlab:2MzX9lwS6W9nU47MuY1qSmk9
 
 after_failure:
-  - "sudo docker exec -it $(docker ps --latest --quiet) cat /home/travis/build/BioDynaMo/biodynamo/build/*.log"
+  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then cat /Users/travis/build/BioDynaMo/biodynamo/build/*.log; fi
+  - if [ ! "$TRAVIS_OS_NAME" = "osx" ]; then sudo docker exec -it $(docker ps --latest --quiet) cat /home/travis/build/BioDynaMo/biodynamo/build/*.log; fi
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,7 @@ notifications:
   slack: cernopenlab:2MzX9lwS6W9nU47MuY1qSmk9
 
 after_failure:
-  - "cat /Users/travis/build/BioDynaMo/biodynamo/build/*.log"
+  - "sudo docker exec -it $(docker ps --latest --quiet) cat /home/travis/build/BioDynaMo/biodynamo/build/*.log"
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,6 +53,7 @@ matrix:
 script:
   - shell_session_update() { :; };
   - $SCRIPT
+  - exit 1;
 
 services:
   - docker


### PR DESCRIPTION
The current solution is outdated from the time that we ran all our builds directly on the Travis machines. Now it's only the OS X machines where this is the case; for the others, we run inside docker. 