### PR TITLE
Fix missing Python 3 symlinks with homebrew on Travis

### DIFF
--- a/util/installation/travis-osx/prerequisites.sh
+++ b/util/installation/travis-osx/prerequisites.sh
@@ -34,6 +34,11 @@ python python@2 llvm wget cmake || true
 
 brew upgrade python cmake || true
 
+# temporary fix to create correct python3 symlinks
+# TODO: remove when we rely fully on Python 3
+brew unlink python@2 || true
+brew link python || true
+
 # Install the optional packages
 if [ $1 == "all" ]; then
     PIP_PACKAGES="nbformat jupyter metakernel"

--- a/util/installation/travis-osx/prerequisites.sh
+++ b/util/installation/travis-osx/prerequisites.sh
@@ -36,8 +36,8 @@ brew upgrade python cmake || true
 
 # temporary fix to create correct python3 symlinks
 # TODO: remove when we rely fully on Python 3
-brew unlink python@2 || true
-brew link python || true
+brew unlink python && brew link python
+ln -sf /usr/local/bin/python3 /usr/local/bin/python
 
 # Install the optional packages
 if [ $1 == "all" ]; then

--- a/util/installation/travis-osx/prerequisites.sh
+++ b/util/installation/travis-osx/prerequisites.sh
@@ -32,20 +32,18 @@ brew update-reset
 brew install libomp tbb open-mpi git \
 python python@2 llvm wget cmake || true
 
-brew upgrade python cmake || true
-
-# temporary fix to create correct python3 symlinks
-# TODO: remove when we rely fully on Python 3
-brew unlink python && brew link python
-ln -sf /usr/local/bin/python3 /usr/local/bin/python
+brew upgrade python || true
+# necessary since symlinking broke with brew on travis since 3.6.7_1 release
+brew link --overwrite python
+brew upgrade cmake || true
 
 # Install the optional packages
 if [ $1 == "all" ]; then
     PIP_PACKAGES="nbformat jupyter metakernel"
     pip2 install --user $PIP_PACKAGES
 
-    # Jupyter relies on tornado for logging, but the latest tornado (from version
-    # 6) is not compatible with Python 2. So we downgrade to 5.1.1
+    # Jupyter relies on tornado for logging, but the latest tornado (version 6)
+    # is not compatible with Python 2. So we downgrade to 5.1.1
     pip2 uninstall tornado -y
     pip2 install --user tornado==5.1.1
     brew install doxygen graphviz lcov gcovr || true


### PR DESCRIPTION
Travis was failing because brew was not creating symlinks for Python 3:

```
==> Upgrading python3 

==> Downloading https://homebrew.bintray.com/bottles/python-3.7.6_1.mojave.bottl

==> Downloading from https://akamai.bintray.com/64/643d627c2b4fc03a3286c397d2992

######################################################################## 100.0%

==> Pouring python-3.7.6_1.mojave.bottle.tar.gz

Error: The `brew link` step did not complete successfully

The formula built, but is not symlinked into /usr/local

Could not symlink Frameworks/Python.framework/Headers

Target /usr/local/Frameworks/Python.framework/Headers

is a symlink belonging to python@2. You can unlink it:

  brew unlink python@2

To force the link and overwrite all conflicting files:

  brew link --overwrite python
```
Since we still need Python 2 (will be removed in near future), the unlink method is not used as it would break the Python 2 symlinks.