### PR TITLE
Automatically load our rootlogon.C upon root invocation

### DIFF
--- a/cmake/BioDynaMo.cmake
+++ b/cmake/BioDynaMo.cmake
@@ -236,15 +236,35 @@ endfunction(build_shared_library)
 # function generate_rootlogon
 # generates rootlogon.C which is required by ROOT's C++ interpreter cling
 function(generate_rootlogon)
-  set(CONTENT "{\n")
+  set(CONTENT "{")
   get_directory_property(INCLUDE_DIRS INCLUDE_DIRECTORIES)
   set(INCLUDE_OPTIONS)
-  foreach( DIR ${INCLUDE_DIRS})
-    set(CONTENT "${CONTENT}\n  gROOT->ProcessLine(\".include ${DIR}\")\;")
-  endforeach()
-  set(CONTENT "${CONTENT}\n  gROOT->ProcessLine(\"R__LOAD_LIBRARY(libbiodynamo)\")\;\n}")
+  
+  # if USE_DICT is set for libbiodynamo.so, we also need to set it for rootcling
+  # when we want to use the interpreter or notebooks. Otherwise there would break
+  # the one-definition rule
+  if (dict)
+    set(CONTENT "${CONTENT}\n  gROOT->ProcessLine(\"#define USE_DICT\")\;")
+  endif()
+
+  set(CONTENT "${CONTENT}\n  gROOT->ProcessLine(\"R__LOAD_LIBRARY(libbiodynamo)\")\;")
+  # We add this one because the ROOT visualization require it, and it's not one
+  # of the core libraries that is loaded by default in rootcling
+  set(CONTENT "${CONTENT}\n  gROOT->ProcessLine(\"R__LOAD_LIBRARY(GenVector)\")\;")
+  set(CONTENT "${CONTENT}\n  gROOT->ProcessLine(\"#include \\\"biodynamo.h\\\"\")\;")
+  set(CONTENT "${CONTENT}\n  gROOT->ProcessLine(\"using namespace bdm\;\")\;")
+  set(CONTENT "${CONTENT}\n}\n")
 
   file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/rootlogon.C" ${CONTENT})
+
+  # If no .rootrc exists in the home directory, then we make one for the
+  # convenience of not having to load our rootlogon.C explicitely for every
+  # cling session.
+  set(ROOTRC_PATH "$ENV{HOME}/.rootrc")
+  set(ROOTRC_CONTENT "Unix.*.Root.MacroPath:      .:$(ROOTSYS)/macros:$(BDMSYS)/etc\n")
+  if(NOT EXISTS "${ROOTRC_PATH}")
+    file(WRITE "${ROOTRC_PATH}" "${ROOTRC_CONTENT}")
+  endif()
 endfunction(generate_rootlogon)
 
 # generates a target to build the biodynamo paraview plugin

--- a/cmake/BioDynaMo.cmake
+++ b/cmake/BioDynaMo.cmake
@@ -236,10 +236,10 @@ endfunction(build_shared_library)
 # function generate_rootlogon
 # generates rootlogon.C which is required by ROOT's C++ interpreter cling
 function(generate_rootlogon)
-  set(CONTENT "{")
   get_directory_property(INCLUDE_DIRS INCLUDE_DIRECTORIES)
   set(INCLUDE_OPTIONS)
-  
+
+  set(CONTENT "{")
   # if USE_DICT is set for libbiodynamo.so, we also need to set it for rootcling
   # when we want to use the interpreter or notebooks. Otherwise there would break
   # the one-definition rule
@@ -254,17 +254,7 @@ function(generate_rootlogon)
   set(CONTENT "${CONTENT}\n  gROOT->ProcessLine(\"#include \\\"biodynamo.h\\\"\")\;")
   set(CONTENT "${CONTENT}\n  gROOT->ProcessLine(\"using namespace bdm\;\")\;")
   set(CONTENT "${CONTENT}\n}\n")
-
   file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/rootlogon.C" ${CONTENT})
-
-  # If no .rootrc exists in the home directory, then we make one for the
-  # convenience of not having to load our rootlogon.C explicitely for every
-  # cling session.
-  set(ROOTRC_PATH "$ENV{HOME}/.rootrc")
-  set(ROOTRC_CONTENT "Unix.*.Root.MacroPath:      .:$(ROOTSYS)/macros:$(BDMSYS)/etc\n")
-  if(NOT EXISTS "${ROOTRC_PATH}")
-    file(WRITE "${ROOTRC_PATH}" "${ROOTRC_CONTENT}")
-  endif()
 endfunction(generate_rootlogon)
 
 # generates a target to build the biodynamo paraview plugin

--- a/cmake/env/thisbdm.sh
+++ b/cmake/env/thisbdm.sh
@@ -223,6 +223,12 @@ fi
 export ROOT_INCLUDE_PATH="${ROOT_INCLUDE_PATH:+${ROOT_INCLUDE_PATH}:}${BDMSYS}/include"
 ########
 
+# Load the rootlogon.C 
+unset -f root || true
+function root {
+  ${BDM_ROOT_DIR}/bin/root -l -e "cout << \"Loading BioDynaMo into ROOT...\" << endl;gROOT->LoadMacro(\"${BDMSYS}/etc/rootlogon.C\");" $@
+}
+
 
 #### ParaView Specific Configurations ####
 if [ -z ${ParaView_DIR} ]; then

--- a/cmake/utils.cmake
+++ b/cmake/utils.cmake
@@ -183,11 +183,16 @@ function(install_inside_build)
             EXCLUDE "biodynamo.py"
             )
     
-     # Copy etc files
-     add_copy_directory(copy_files_bdm
+    # Copy etc files
+    add_copy_directory(copy_files_bdm
             ${CMAKE_SOURCE_DIR}/etc
             DESTINATION ${CMAKE_INSTALL_ROOT}/etc
             GLOB "*" ".*"
+            )
+
+    add_copy_files(copy_files_bdm
+            ${CMAKE_BINARY_DIR}/rootlogon.C
+            DESTINATION ${CMAKE_INSTALL_ROOT}/etc
             )
 
     add_copy_files(copy_files_bdm


### PR DESCRIPTION
This alleviates users from having to have rootlogon.C in the current working directory for it to be picked up by ROOT.

Also, we removed unnecessary lines in rootlogon.C and added some useful ones. Mainly the #define USE_DICT line avoids segmentation faults from happing in rootcling / notebook (could break the one-definition rule): https://root-forum.cern.ch/t/program-crashes-in-cling-only-when-dictionaries-are-built/37178/18
