### PR TITLE
Add fine-grained thread safety mechanism

### DIFF
--- a/demo/soma_clustering/src/soma_clustering.h
+++ b/demo/soma_clustering/src/soma_clustering.h
@@ -43,9 +43,6 @@ inline int Simulate(int argc, const char** argv) {
   };
 
   Simulation simulation(argc, argv, set_param);
-  // Since sim_objects in this simulation won't modify neighbors, we can
-  // safely disable neighbor guards to improve performance.
-  simulation.GetExecutionContext()->DisableNeighborGuard();
 
   // Define initial model
   auto* param = simulation.GetParam();

--- a/demo/tumor_concept/src/tumor_concept.h
+++ b/demo/tumor_concept/src/tumor_concept.h
@@ -116,9 +116,6 @@ inline int Simulate(int argc, const char** argv) {
   auto* rm = simulation.GetResourceManager();
   auto* param = simulation.GetParam();
   auto* myrand = simulation.GetRandom();
-  // Since `sim_objects` in this simulation won't modify neighbors, we can
-  // safely disable neighbor guards to improve performance.
-  simulation.GetExecutionContext()->DisableNeighborGuard();
 
   size_t nb_of_cells = 2400;  // number of cells in the simulation
   double x_coord, y_coord, z_coord;

--- a/src/core/execution_context/in_place_exec_ctxt.cc
+++ b/src/core/execution_context/in_place_exec_ctxt.cc
@@ -192,9 +192,9 @@ void InPlaceExecutionContext::Execute(
   if (true) {
     // auto mutex = nb_mutex_builder->GetMutex(so->GetBoxIdx());
     // std::lock_guard<decltype(mutex)> guard(mutex);
-    std::set<Spinlock*> locks;
-    locks.insert(so->GetLock());
+    locks.push_back(so->GetLock());
     so->CriticalRegion(&locks);
+    std::sort(locks.begin(), locks.end());
     for(auto* l : locks) {
       l->lock();
     }
@@ -205,6 +205,7 @@ void InPlaceExecutionContext::Execute(
     for(auto* l : locks) {
       l->unlock();
     }
+    locks.clear();
   } else {
     neighbor_cache_.clear();
     for (auto& op : operations) {

--- a/src/core/execution_context/in_place_exec_ctxt.cc
+++ b/src/core/execution_context/in_place_exec_ctxt.cc
@@ -217,7 +217,7 @@ void InPlaceExecutionContext::Execute(
       op(so);
     }
   } else {
-    Log::Fatal("InPlaceExecutionContext::Execut", "Invalid value for parameter thread_safety_mechanism_: ", param->thread_safety_mechanism_);
+    Log::Fatal("InPlaceExecutionContext::Execute", "Invalid value for parameter thread_safety_mechanism_: ", param->thread_safety_mechanism_);
   }
 }
 

--- a/src/core/execution_context/in_place_exec_ctxt.cc
+++ b/src/core/execution_context/in_place_exec_ctxt.cc
@@ -189,21 +189,23 @@ void InPlaceExecutionContext::Execute(
   auto* grid = Simulation::GetActive()->GetGrid();
   auto* param = Simulation::GetActive()->GetParam();
 
-  if (param->thread_safety_mechanism_ == Param::ThreadSafetyMechanism::kUserSpecified) {
+  if (param->thread_safety_mechanism_ ==
+      Param::ThreadSafetyMechanism::kUserSpecified) {
     so->CriticalRegion(&locks);
     std::sort(locks.begin(), locks.end());
-    for(auto* l : locks) {
+    for (auto* l : locks) {
       l->lock();
     }
     neighbor_cache_.clear();
     for (auto& op : operations) {
       op(so);
     }
-    for(auto* l : locks) {
+    for (auto* l : locks) {
       l->unlock();
     }
     locks.clear();
-  } else if (param->thread_safety_mechanism_ == Param::ThreadSafetyMechanism::kAutomatic) {
+  } else if (param->thread_safety_mechanism_ ==
+             Param::ThreadSafetyMechanism::kAutomatic) {
     auto* nb_mutex_builder = grid->GetNeighborMutexBuilder();
     auto mutex = nb_mutex_builder->GetMutex(so->GetBoxIdx());
     std::lock_guard<decltype(mutex)> guard(mutex);
@@ -211,13 +213,16 @@ void InPlaceExecutionContext::Execute(
     for (auto& op : operations) {
       op(so);
     }
-  } else if (param->thread_safety_mechanism_ == Param::ThreadSafetyMechanism::kNone) {
+  } else if (param->thread_safety_mechanism_ ==
+             Param::ThreadSafetyMechanism::kNone) {
     neighbor_cache_.clear();
     for (auto& op : operations) {
       op(so);
     }
   } else {
-    Log::Fatal("InPlaceExecutionContext::Execute", "Invalid value for parameter thread_safety_mechanism_: ", param->thread_safety_mechanism_);
+    Log::Fatal("InPlaceExecutionContext::Execute",
+               "Invalid value for parameter thread_safety_mechanism_: ",
+               param->thread_safety_mechanism_);
   }
 }
 

--- a/src/core/execution_context/in_place_exec_ctxt.cc
+++ b/src/core/execution_context/in_place_exec_ctxt.cc
@@ -190,7 +190,6 @@ void InPlaceExecutionContext::Execute(
   auto* param = Simulation::GetActive()->GetParam();
 
   if (param->thread_safety_mechanism_ == Param::ThreadSafetyMechanism::kUserSpecified) {
-    locks.push_back(so->GetLock());
     so->CriticalRegion(&locks);
     std::sort(locks.begin(), locks.end());
     for(auto* l : locks) {

--- a/src/core/execution_context/in_place_exec_ctxt.cc
+++ b/src/core/execution_context/in_place_exec_ctxt.cc
@@ -305,10 +305,6 @@ void InPlaceExecutionContext::RemoveFromSimulation(const SoUid& uid) {
   remove_.push_back(uid);
 }
 
-void InPlaceExecutionContext::DisableNeighborGuard() {
-  Simulation::GetActive()->GetGrid()->DisableNeighborMutexes();
-}
-
 // TODO(lukas) Add tests for caching mechanism in ForEachNeighbor*
 
 }  // namespace bdm

--- a/src/core/execution_context/in_place_exec_ctxt.h
+++ b/src/core/execution_context/in_place_exec_ctxt.h
@@ -25,7 +25,6 @@
 #include "core/sim_object/so_uid.h"
 #include "core/util/spinlock.h"
 #include "core/util/thread_info.h"
-#include "core/util/spinlock.h"
 
 namespace bdm {
 

--- a/src/core/execution_context/in_place_exec_ctxt.h
+++ b/src/core/execution_context/in_place_exec_ctxt.h
@@ -41,9 +41,7 @@ class SimObject;
 /// Subsequent operations observe the changes of earlier operations.\n
 /// In-place updates can lead to race conditions if simulation objects not only
 /// modify themselves, but also neighbors. Therefore, a protection mechanism has
-/// been added. If neighbors are not modified, this protection can be turned off
-///  to improve performance using `DisableNeighborGuard()`. By default it is
-/// turned on.\n
+/// been added. \see `Param::thread_safety_mechanism_`
 /// New sim objects will only be visible at the next iteration. \n
 /// Also removal of a sim object happens at the end of each iteration.
 class InPlaceExecutionContext {
@@ -107,12 +105,6 @@ class InPlaceExecutionContext {
   const SimObject* GetConstSimObject(const SoUid& uid);
 
   void RemoveFromSimulation(const SoUid& uid);
-
-  /// If a sim objects modifies other simulation objects while it is updated,
-  /// race conditions can occur using this execution context. This function
-  /// turns the protection mechanism off to improve performance. This is safe
-  /// simulation objects only update themselves.
-  void DisableNeighborGuard();
 
  private:
   /// Lookup table SoUid -> SoPointer for new created sim objects

--- a/src/core/execution_context/in_place_exec_ctxt.h
+++ b/src/core/execution_context/in_place_exec_ctxt.h
@@ -25,6 +25,7 @@
 #include "core/sim_object/so_uid.h"
 #include "core/util/spinlock.h"
 #include "core/util/thread_info.h"
+#include "core/util/spinlock.h"
 
 namespace bdm {
 
@@ -122,6 +123,7 @@ class InPlaceExecutionContext {
   /// Contains unique ids of sim objects that will be removed at the end of each
   /// iteration.
   std::vector<SoUid> remove_;
+  std::vector<Spinlock*> locks;
 
   /// Pointer to new sim objects
   std::vector<SimObject*> new_sim_objects_;

--- a/src/core/grid.h
+++ b/src/core/grid.h
@@ -359,7 +359,7 @@ class Grid {
         threshold_dimensions_ = {min, max};
       }
 
-      if (nb_mutex_builder_ != nullptr) {
+      if (param->thread_safety_mechanism_ == Param::ThreadSafetyMechanism::kAutomatic) {
         nb_mutex_builder_->Update();
       }
     } else {
@@ -726,13 +726,8 @@ class Grid {
     std::vector<MutexWrapper> mutexes_;
   };
 
-  /// Disable neighbor mutexes management. `GetNeighborMutexBuilder()` will
-  /// return a nullptr.
-  void DisableNeighborMutexes() { nb_mutex_builder_ = nullptr; }
-
   /// Returns the `NeighborMutexBuilder`. The client use it to create a
-  /// `NeighborMutex`. If neighbor mutexes has been disabled by calling
-  /// `DisableNeighborMutexes`, this function will return a nullptr.
+  /// `NeighborMutex`.
   NeighborMutexBuilder* GetNeighborMutexBuilder() {
     return nb_mutex_builder_.get();
   }
@@ -774,8 +769,9 @@ class Grid {
   /// stores pairs of <box morton code,  box pointer> sorted by morton code.
   ParallelResizeVector<std::pair<uint32_t, const Box*>> zorder_sorted_boxes_;
 
-  /// Holds instance of NeighborMutexBuilder if it is enabled.
-  /// If `DisableNeighborMutexes` has been called this member set to nullptr.
+  /// Holds instance of NeighborMutexBuilder.
+  /// NeighborMutexBuilder is updated if `Param::thread_safety_mechanism_`
+  /// is set to `kAutomatic`
   std::unique_ptr<NeighborMutexBuilder> nb_mutex_builder_ =
       std::make_unique<NeighborMutexBuilder>();
 

--- a/src/core/grid.h
+++ b/src/core/grid.h
@@ -359,7 +359,8 @@ class Grid {
         threshold_dimensions_ = {min, max};
       }
 
-      if (param->thread_safety_mechanism_ == Param::ThreadSafetyMechanism::kAutomatic) {
+      if (param->thread_safety_mechanism_ ==
+          Param::ThreadSafetyMechanism::kAutomatic) {
         nb_mutex_builder_->Update();
       }
     } else {

--- a/src/core/param/param.cc
+++ b/src/core/param/param.cc
@@ -46,6 +46,30 @@ void Param::Restore(Param&& other) {
   other.modules_.clear();
 }
 
+void AssignThreadSafetyMechanism(const std::shared_ptr<cpptoml::table>& config, Param* param) {
+  const std::string config_key = "simulation.thread_safety_mechanism";
+  std::cout << "FOO 1" << std::endl;
+  if (config->contains_qualified(config_key)) {
+    std::cout << "FOO 2" << std::endl;
+    auto value = config->get_qualified_as<std::string>(config_key);
+    std::cout << "FOO 3" << std::endl;
+    if (!value) {
+      return;
+    }
+    std::cout << "FOO 4" << std::endl;
+    auto str_value = *value;
+    std::cout << "FOO 5" << std::endl;
+    if (str_value == "none") {
+      param->thread_safety_mechanism_ = Param::ThreadSafetyMechanism::kNone;
+    } else if (str_value == "user-specified") {
+      param->thread_safety_mechanism_ = Param::ThreadSafetyMechanism::kUserSpecified;
+    } else if (str_value == "automatic") {
+      param->thread_safety_mechanism_ = Param::ThreadSafetyMechanism::kAutomatic;
+    }
+    std::cout << "FOO 6" << std::endl;
+  }
+}
+
 void Param::AssignFromConfig(const std::shared_ptr<cpptoml::table>& config) {
   // module parameters
   for (auto& el : modules_) {
@@ -68,6 +92,8 @@ void Param::AssignFromConfig(const std::shared_ptr<cpptoml::table>& config) {
   BDM_ASSIGN_CONFIG_VALUE(leaking_edges_, "simulation.leaking_edges");
   BDM_ASSIGN_CONFIG_VALUE(calculate_gradients_,
                           "simulation.calculate_gradients");
+  AssignThreadSafetyMechanism(config, this);
+
   // visualization group
   BDM_ASSIGN_CONFIG_VALUE(visualization_engine_, "visualization.adaptor");
   BDM_ASSIGN_CONFIG_VALUE(live_visualization_, "visualization.live");

--- a/src/core/param/param.cc
+++ b/src/core/param/param.cc
@@ -46,7 +46,8 @@ void Param::Restore(Param&& other) {
   other.modules_.clear();
 }
 
-void AssignThreadSafetyMechanism(const std::shared_ptr<cpptoml::table>& config, Param* param) {
+void AssignThreadSafetyMechanism(const std::shared_ptr<cpptoml::table>& config,
+                                 Param* param) {
   const std::string config_key = "simulation.thread_safety_mechanism";
   if (config->contains_qualified(config_key)) {
     auto value = config->get_qualified_as<std::string>(config_key);
@@ -57,9 +58,11 @@ void AssignThreadSafetyMechanism(const std::shared_ptr<cpptoml::table>& config, 
     if (str_value == "none") {
       param->thread_safety_mechanism_ = Param::ThreadSafetyMechanism::kNone;
     } else if (str_value == "user-specified") {
-      param->thread_safety_mechanism_ = Param::ThreadSafetyMechanism::kUserSpecified;
+      param->thread_safety_mechanism_ =
+          Param::ThreadSafetyMechanism::kUserSpecified;
     } else if (str_value == "automatic") {
-      param->thread_safety_mechanism_ = Param::ThreadSafetyMechanism::kAutomatic;
+      param->thread_safety_mechanism_ =
+          Param::ThreadSafetyMechanism::kAutomatic;
     }
   }
 }

--- a/src/core/param/param.cc
+++ b/src/core/param/param.cc
@@ -48,17 +48,12 @@ void Param::Restore(Param&& other) {
 
 void AssignThreadSafetyMechanism(const std::shared_ptr<cpptoml::table>& config, Param* param) {
   const std::string config_key = "simulation.thread_safety_mechanism";
-  std::cout << "FOO 1" << std::endl;
   if (config->contains_qualified(config_key)) {
-    std::cout << "FOO 2" << std::endl;
     auto value = config->get_qualified_as<std::string>(config_key);
-    std::cout << "FOO 3" << std::endl;
     if (!value) {
       return;
     }
-    std::cout << "FOO 4" << std::endl;
     auto str_value = *value;
-    std::cout << "FOO 5" << std::endl;
     if (str_value == "none") {
       param->thread_safety_mechanism_ = Param::ThreadSafetyMechanism::kNone;
     } else if (str_value == "user-specified") {
@@ -66,7 +61,6 @@ void AssignThreadSafetyMechanism(const std::shared_ptr<cpptoml::table>& config, 
     } else if (str_value == "automatic") {
       param->thread_safety_mechanism_ = Param::ThreadSafetyMechanism::kAutomatic;
     }
-    std::cout << "FOO 6" << std::endl;
   }
 }
 

--- a/src/core/param/param.h
+++ b/src/core/param/param.h
@@ -167,6 +167,19 @@ struct Param {
   ///     calculate_gradients = true
   bool calculate_gradients_ = true;
 
+  /// List of thread-safety mechanisms \n
+  /// `kNone`: \n
+  /// `kUserSpecified`:
+  /// `kAutomatic`:
+  enum ThreadSafetyMechanism { kNone = 0, kUserSpecified, kAutomatic };
+  /// Select the thread-safety mechanism.\n
+  /// Possible values are: none, user-specified, automatic.\n
+  /// TOML config file:
+  ///
+  ///     [simulation]
+  ///     thread_safety_mechanism_ = "none"
+  ThreadSafetyMechanism thread_safety_mechanism_ = ThreadSafetyMechanism::kUserSpecified;
+
   // visualization values ------------------------------------------------------
 
   /// Name of the visualization engine to use for visualizaing BioDynaMo

--- a/src/core/param/param.h
+++ b/src/core/param/param.h
@@ -180,7 +180,8 @@ struct Param {
   ///
   ///     [simulation]
   ///     thread_safety_mechanism_ = "none"
-  ThreadSafetyMechanism thread_safety_mechanism_ = ThreadSafetyMechanism::kUserSpecified;
+  ThreadSafetyMechanism thread_safety_mechanism_ =
+      ThreadSafetyMechanism::kUserSpecified;
 
   // visualization values ------------------------------------------------------
 

--- a/src/core/param/param.h
+++ b/src/core/param/param.h
@@ -169,8 +169,10 @@ struct Param {
 
   /// List of thread-safety mechanisms \n
   /// `kNone`: \n
-  /// `kUserSpecified`:
-  /// `kAutomatic`:
+  /// `kUserSpecified`: The user has to define all simulation object that must
+  /// not be processed in parallel. \see `SimObject::CriticalRegion`.\n
+  /// `kAutomatic`: The simulation automatically locks all simulation objects
+  /// of the microenvironment.
   enum ThreadSafetyMechanism { kNone = 0, kUserSpecified, kAutomatic };
   /// Select the thread-safety mechanism.\n
   /// Possible values are: none, user-specified, automatic.\n

--- a/src/core/sim_object/sim_object.h
+++ b/src/core/sim_object/sim_object.h
@@ -179,6 +179,14 @@ class SimObject {
   const SoUid& GetUid() const;
 
   Spinlock* GetLock() { return &lock_; }
+
+  /// If the thread-safety mechanism is set to user-specified this function
+  /// will be called before the operations are executed for this simulation
+  /// object.\n
+  /// Subclasses define the critical region by adding the locks of all
+  /// simulation objects that must not be processed in parallel. \n
+  /// Don't forget to add the lock of the current simulation object.\n
+  /// \see `Param::thread_safety_mechanism_`
   virtual void CriticalRegion(std::vector<Spinlock*>* locks) {}
 
   uint32_t GetBoxIdx() const;

--- a/src/core/sim_object/sim_object.h
+++ b/src/core/sim_object/sim_object.h
@@ -179,7 +179,7 @@ class SimObject {
   const SoUid& GetUid() const;
 
   Spinlock* GetLock() { return &lock_; }
-  virtual void CriticalRegion(std::set<Spinlock*>* locks) {}
+  virtual void CriticalRegion(std::vector<Spinlock*>* locks) {}
 
   uint32_t GetBoxIdx() const;
 

--- a/src/core/sim_object/sim_object.h
+++ b/src/core/sim_object/sim_object.h
@@ -261,7 +261,7 @@ class SimObject {
   std::vector<BaseBiologyModule*> biology_modules_;
 
  private:
-   Spinlock lock_;
+  Spinlock lock_;
 
   /// Helper variable used to support removal of biology modules while
   /// `RunBiologyModules` iterates over them.

--- a/src/core/sim_object/sim_object.h
+++ b/src/core/sim_object/sim_object.h
@@ -33,6 +33,7 @@
 #include "core/sim_object/so_visitor.h"
 #include "core/util/macros.h"
 #include "core/util/root.h"
+#include "core/util/spinlock.h"
 
 namespace bdm {
 
@@ -177,6 +178,9 @@ class SimObject {
 
   const SoUid& GetUid() const;
 
+  Spinlock* GetLock() { return &lock_; }
+  virtual void CriticalRegion(std::set<Spinlock*>* locks) {}
+
   uint32_t GetBoxIdx() const;
 
   void SetBoxIdx(uint32_t idx);
@@ -249,6 +253,8 @@ class SimObject {
   std::vector<BaseBiologyModule*> biology_modules_;
 
  private:
+   Spinlock lock_;
+
   /// Helper variable used to support removal of biology modules while
   /// `RunBiologyModules` iterates over them.
   uint32_t run_bm_loop_idx_ = 0;

--- a/src/core/util/spinlock.h
+++ b/src/core/util/spinlock.h
@@ -17,6 +17,8 @@
 
 #include <atomic>
 
+namespace bdm {
+
 class Spinlock {
  public:
   Spinlock() {}
@@ -35,5 +37,7 @@ class Spinlock {
  private:
   std::atomic_flag flag_ = ATOMIC_FLAG_INIT;
 };
+
+}  // namespace bdm
 
 #endif  // CORE_UTIL_SPINLOCK_H_

--- a/src/neuroscience/neurite_element.h
+++ b/src/neuroscience/neurite_element.h
@@ -166,6 +166,17 @@ class NeuriteElement : public SimObject, public NeuronOrNeurite {
   }
 
   const SoUid& GetUid() const override { return Base::GetUid(); }
+  Spinlock* GetLock() override { return Base::GetLock(); }
+  void CriticalRegion(std::set<Spinlock*>* locks) override {
+    locks->insert(mother_->GetLock());
+    if (daughter_left_ != nullptr) {
+      locks->insert(daughter_left_->GetLock());
+    }
+    if (daughter_right_ != nullptr) {
+      locks->insert(daughter_right_->GetLock());
+    }
+  }
+
 
   Shape GetShape() const override { return Shape::kCylinder; }
 

--- a/src/neuroscience/neurite_element.h
+++ b/src/neuroscience/neurite_element.h
@@ -167,13 +167,13 @@ class NeuriteElement : public SimObject, public NeuronOrNeurite {
 
   const SoUid& GetUid() const override { return Base::GetUid(); }
   Spinlock* GetLock() override { return Base::GetLock(); }
-  void CriticalRegion(std::set<Spinlock*>* locks) override {
-    locks->insert(mother_->GetLock());
+  void CriticalRegion(std::vector<Spinlock*>* locks) override {
+    locks->push_back(mother_->GetLock());
     if (daughter_left_ != nullptr) {
-      locks->insert(daughter_left_->GetLock());
+      locks->push_back(daughter_left_->GetLock());
     }
     if (daughter_right_ != nullptr) {
-      locks->insert(daughter_right_->GetLock());
+      locks->push_back(daughter_right_->GetLock());
     }
   }
 

--- a/src/neuroscience/neurite_element.h
+++ b/src/neuroscience/neurite_element.h
@@ -166,8 +166,12 @@ class NeuriteElement : public SimObject, public NeuronOrNeurite {
   }
 
   const SoUid& GetUid() const override { return Base::GetUid(); }
+
   Spinlock* GetLock() override { return Base::GetLock(); }
+
   void CriticalRegion(std::vector<Spinlock*>* locks) override {
+    locks->reserve(4);
+    locks->push_back(GetLock());
     locks->push_back(mother_->GetLock());
     if (daughter_left_ != nullptr) {
       locks->push_back(daughter_left_->GetLock());

--- a/src/neuroscience/neurite_element.h
+++ b/src/neuroscience/neurite_element.h
@@ -181,7 +181,6 @@ class NeuriteElement : public SimObject, public NeuronOrNeurite {
     }
   }
 
-
   Shape GetShape() const override { return Shape::kCylinder; }
 
   /// Returns the data members that are required to visualize this simulation

--- a/src/neuroscience/neuron_or_neurite.h
+++ b/src/neuroscience/neuron_or_neurite.h
@@ -21,6 +21,9 @@
 #include "core/sim_object/so_pointer.h"
 
 namespace bdm {
+
+class Spinlock;
+
 namespace experimental {
 namespace neuroscience {
 
@@ -34,6 +37,7 @@ class NeuronOrNeurite {
   virtual ~NeuronOrNeurite();
 
   virtual const SoUid& GetUid() const = 0;
+  virtual Spinlock* GetLock() = 0;
 
   SoPointer<NeuronOrNeurite> GetNeuronOrNeuriteSoPtr() const;
 

--- a/src/neuroscience/neuron_soma.cc
+++ b/src/neuroscience/neuron_soma.cc
@@ -139,7 +139,7 @@ const std::vector<SoPointer<NeuriteElement>>& NeuronSoma::GetDaughters() const {
 void NeuronSoma::CriticalRegion(std::vector<Spinlock*>* locks) {
   locks->reserve(daughters_.size() + 1);
   locks->push_back(GetLock());
-  for(auto& daughter : daughters_) {
+  for (auto& daughter : daughters_) {
     locks->push_back(daughter->GetLock());
   }
 }

--- a/src/neuroscience/neuron_soma.cc
+++ b/src/neuroscience/neuron_soma.cc
@@ -136,6 +136,14 @@ const std::vector<SoPointer<NeuriteElement>>& NeuronSoma::GetDaughters() const {
   return daughters_;
 }
 
+void NeuronSoma::CriticalRegion(std::vector<Spinlock*>* locks) {
+  locks->reserve(daughters_.size() + 1);
+  locks->push_back(GetLock());
+  for(auto& daughter : daughters_) {
+    locks->push_back(daughter->GetLock());
+  }
+}
+
 }  // namespace neuroscience
 }  // namespace experimental
 }  // namespace bdm

--- a/src/neuroscience/neuron_soma.h
+++ b/src/neuroscience/neuron_soma.h
@@ -62,6 +62,10 @@ class NeuronSoma : public Cell, public NeuronOrNeurite {
                     SimObject* other2 = nullptr) override;
 
   const SoUid& GetUid() const override { return Base::GetUid(); }
+  Spinlock* GetLock() override { return Base::GetLock(); }
+  void CriticalRegion(std::set<Spinlock*>* locks) override {
+    // FIXME
+  }
 
   // ***************************************************************************
   //      METHODS FOR NEURON TREE STRUCTURE *

--- a/src/neuroscience/neuron_soma.h
+++ b/src/neuroscience/neuron_soma.h
@@ -62,10 +62,10 @@ class NeuronSoma : public Cell, public NeuronOrNeurite {
                     SimObject* other2 = nullptr) override;
 
   const SoUid& GetUid() const override { return Base::GetUid(); }
+
   Spinlock* GetLock() override { return Base::GetLock(); }
-  void CriticalRegion(std::vector<Spinlock*>* locks) override {
-    // FIXME
-  }
+
+  void CriticalRegion(std::vector<Spinlock*>* locks) override;
 
   // ***************************************************************************
   //      METHODS FOR NEURON TREE STRUCTURE *

--- a/src/neuroscience/neuron_soma.h
+++ b/src/neuroscience/neuron_soma.h
@@ -63,7 +63,7 @@ class NeuronSoma : public Cell, public NeuronOrNeurite {
 
   const SoUid& GetUid() const override { return Base::GetUid(); }
   Spinlock* GetLock() override { return Base::GetLock(); }
-  void CriticalRegion(std::set<Spinlock*>* locks) override {
+  void CriticalRegion(std::vector<Spinlock*>* locks) override {
     // FIXME
   }
 

--- a/test/unit/core/execution_context/in_place_exec_ctxt_test.cc
+++ b/test/unit/core/execution_context/in_place_exec_ctxt_test.cc
@@ -134,8 +134,6 @@ TEST(InPlaceExecutionContext, Execute) {
   Simulation sim(TEST_NAME);
   auto* ctxt = sim.GetExecutionContext();
 
-  ctxt->DisableNeighborGuard();
-
   Cell cell_0;
   cell_0.SetDiameter(123);
   auto uid_0 = cell_0.GetUid();

--- a/test/unit/core/execution_context/in_place_exec_ctxt_test.cc
+++ b/test/unit/core/execution_context/in_place_exec_ctxt_test.cc
@@ -163,10 +163,11 @@ TEST(InPlaceExecutionContext, Execute) {
   EXPECT_TRUE(op2_called);
 }
 
-void RunInPlaceExecutionContextExecuteThreadSafety(Param::ThreadSafetyMechanism mechanism) {
-  Simulation sim("RunInPlaceExecutionContextExecuteThreadSafety", [&](Param* param) {
-    param->thread_safety_mechanism_ = mechanism;
-  });
+void RunInPlaceExecutionContextExecuteThreadSafety(
+    Param::ThreadSafetyMechanism mechanism) {
+  Simulation sim(
+      "RunInPlaceExecutionContextExecuteThreadSafety",
+      [&](Param* param) { param->thread_safety_mechanism_ = mechanism; });
   auto* rm = sim.GetResourceManager();
 
   // create cells
@@ -201,7 +202,7 @@ void RunInPlaceExecutionContextExecuteThreadSafety(Param::ThreadSafetyMechanism 
     // one corresponding to the master thread
     auto* ctxt = sim.GetExecutionContext();
     ctxt->ForEachNeighborWithinRadius(nb_lambda, *so, 100);
-  #pragma omp critical
+#pragma omp critical
     num_neighbors[so->GetUid()] = nb_counter;
   });
 
@@ -218,12 +219,15 @@ void RunInPlaceExecutionContextExecuteThreadSafety(Param::ThreadSafetyMechanism 
   });
 }
 
-TEST(InPlaceExecutionContext, ExecuteThreadSafetyTestWithUserSpecifiedThreadSafety) {
-  RunInPlaceExecutionContextExecuteThreadSafety(Param::ThreadSafetyMechanism::kUserSpecified);
+TEST(InPlaceExecutionContext,
+     ExecuteThreadSafetyTestWithUserSpecifiedThreadSafety) {
+  RunInPlaceExecutionContextExecuteThreadSafety(
+      Param::ThreadSafetyMechanism::kUserSpecified);
 }
 
 TEST(InPlaceExecutionContext, ExecuteThreadSafetyTestAutomaticThreadSafety) {
-  RunInPlaceExecutionContextExecuteThreadSafety(Param::ThreadSafetyMechanism::kAutomatic);
+  RunInPlaceExecutionContextExecuteThreadSafety(
+      Param::ThreadSafetyMechanism::kAutomatic);
 }
 
 TEST(InPlaceExecutionContext, PushBackMultithreadingTest) {

--- a/test/unit/core/simulation_test.cc
+++ b/test/unit/core/simulation_test.cc
@@ -40,6 +40,7 @@ class SimulationTest : public ::testing::Test {
       "bound_space = true\n"
       "min_bound = -100\n"
       "max_bound =  200\n"
+      "thread_safety_mechanism = \"automatic\"\n"
       "\n"
       "[visualization]\n"
       "live = false\n"
@@ -108,6 +109,7 @@ class SimulationTest : public ::testing::Test {
     EXPECT_TRUE(param->bound_space_);
     EXPECT_EQ(-100, param->min_bound_);
     EXPECT_EQ(200, param->max_bound_);
+    EXPECT_EQ(Param::ThreadSafetyMechanism::kAutomatic, param->thread_safety_mechanism_);
     EXPECT_FALSE(param->live_visualization_);
     EXPECT_TRUE(param->export_visualization_);
     EXPECT_EQ(100u, param->visualization_export_interval_);

--- a/test/unit/core/simulation_test.cc
+++ b/test/unit/core/simulation_test.cc
@@ -109,7 +109,8 @@ class SimulationTest : public ::testing::Test {
     EXPECT_TRUE(param->bound_space_);
     EXPECT_EQ(-100, param->min_bound_);
     EXPECT_EQ(200, param->max_bound_);
-    EXPECT_EQ(Param::ThreadSafetyMechanism::kAutomatic, param->thread_safety_mechanism_);
+    EXPECT_EQ(Param::ThreadSafetyMechanism::kAutomatic,
+              param->thread_safety_mechanism_);
     EXPECT_FALSE(param->live_visualization_);
     EXPECT_TRUE(param->export_visualization_);
     EXPECT_EQ(100u, param->visualization_export_interval_);


### PR DESCRIPTION
This thread-safety mechanism relies on the user to specify which simulation
objects must not be modified at the same time.
The current solution locks the whole microenvironment.
Param::thread_safety_mechanism_ lets users decide which ones they prefer
(kNone, kUserSpecified, or kAutomatic)