### PR TITLE
Fix query of current branch name in GHA for scheduled workflows

### DIFF
--- a/.github/workflows/centos-system-ci.yml
+++ b/.github/workflows/centos-system-ci.yml
@@ -20,6 +20,15 @@ jobs:
       image: centos:7
 
     steps:
+    - name: Set GHA_BRANCH_NAME
+      run: |
+        if [ "${{ github.event_name }}" = "pull_request" ]; then
+          echo "::set-env name=GHA_BRANCH_NAME::${{ github.head_ref }}"
+        fi
+        if [ "${{ github.event_name }}" = "schedule" ]; then
+          echo "::set-env name=GHA_BRANCH_NAME::${GITHUB_REF#refs/heads/}"
+        fi
+    
       # Do this prior to Checkout BioDynaMo, because the CentOS docker container
       # does not come with git preinstalled. This would mess up later calls to 
       # `git describe --tags`
@@ -34,7 +43,7 @@ jobs:
       run: |
         yum update -y
         yum install -y sudo curl
-        curl https://raw.githubusercontent.com/BioDynaMo/biodynamo/${{ github.head_ref }}/util/install | bash
+        curl https://raw.githubusercontent.com/BioDynaMo/biodynamo/${GHA_BRANCH_NAME}/util/install | bash
 
     - name: Checkout BioDynaMo
       uses: actions/checkout@v2

--- a/.github/workflows/macos-system-ci.yml
+++ b/.github/workflows/macos-system-ci.yml
@@ -18,12 +18,21 @@ jobs:
     runs-on: macos-latest
 
     steps:
+    - name: Set GHA_BRANCH_NAME
+      run: |
+        if [ "${{ github.event_name }}" = "pull_request" ]; then
+          echo "::set-env name=GHA_BRANCH_NAME::${{ github.head_ref }}"
+        fi
+        if [ "${{ github.event_name }}" = "schedule" ]; then
+          echo "::set-env name=GHA_BRANCH_NAME::${GITHUB_REF#refs/heads/}"
+        fi
+    
     - name: Install BioDynaMo
       shell: bash
       run: |
         brew update
         brew install curl
-        curl https://raw.githubusercontent.com/BioDynaMo/biodynamo/${{ github.head_ref }}/util/install | bash
+        curl https://raw.githubusercontent.com/BioDynaMo/biodynamo/${GHA_BRANCH_NAME}/util/install | bash
 
     - name: Checkout BioDynaMo
       uses: actions/checkout@v2

--- a/.github/workflows/ubuntu-system-ci.yml
+++ b/.github/workflows/ubuntu-system-ci.yml
@@ -21,12 +21,21 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
+    - name: Set GHA_BRANCH_NAME
+      run: |
+        if [ "${{ github.event_name }}" = "pull_request" ]; then
+          echo "::set-env name=GHA_BRANCH_NAME::${{ github.head_ref }}"
+        fi
+        if [ "${{ github.event_name }}" = "schedule" ]; then
+          echo "::set-env name=GHA_BRANCH_NAME::${GITHUB_REF#refs/heads/}"
+        fi
+
     - name: Install BioDynaMo
       shell: bash
       run: |
         sudo apt update
         sudo apt install -y curl
-        curl https://raw.githubusercontent.com/BioDynaMo/biodynamo/${{ github.head_ref }}/util/install | bash
+        curl https://raw.githubusercontent.com/BioDynaMo/biodynamo/${GHA_BRANCH_NAME}/util/install | bash
 
     - name: Checkout BioDynaMo
       uses: actions/checkout@v2

--- a/util/install
+++ b/util/install
@@ -22,7 +22,7 @@ FailedCheckout() {
 Checkout() {
   # In Github Actions we checkout the branch that is running the install script
   if [ ! -z ${GITHUB_ACTIONS+x} ]; then
-    [ -d "$2" ] || git clone --branch ${GITHUB_REF#refs/heads/} "$1" "$2" || FailedCheckout "$1"
+    [ -d "$2" ] || git clone --branch ${GHA_BRANCH_NAME} "$1" "$2" || FailedCheckout "$1"
   else
     [ -d "$2" ] || git clone --branch master "$1" "$2" || FailedCheckout "$1"
   fi


### PR DESCRIPTION
There is no single way with Github Actions to obtain the branch
name for both pull requests and schedule workflows. We set an
environmental variable (GHA_BRANCH_NAME) depending on the workflow
event name