### PR TITLE
Improve scheduling of operations. Fix ordering issues.

### DIFF
--- a/cmake/Testing.cmake
+++ b/cmake/Testing.cmake
@@ -82,9 +82,9 @@ function(bdm_add_test_executable TEST_TARGET)
   if (valgrind AND VALGRIND_FOUND AND NOT coverage)
     # filter out SchedulerTest.Backup because of timing issue
     add_test(NAME "valgrind_${TEST_TARGET}"
-    COMMAND  ${CMAKE_BINARY_DIR}/launcher.sh ${CMAKE_SOURCE_DIR}/util/valgrind.sh ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${TEST_TARGET} -- --gtest_filter=-*DeathTest.*:IOTest.InvalidRead:SchedulerTest.Backup:ResourceManagerTest.SortAndApplyOnAllElementsParallel*:InlineVector*:NeuriteElementBehaviour.*:MechanicalInteraction.*:DiffusionTest.*Convergence*)
+    COMMAND  ${CMAKE_BINARY_DIR}/launcher.sh ${CMAKE_SOURCE_DIR}/util/valgrind.sh ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${TEST_TARGET} -- --gtest_filter=-*DeathTest.*:IOTest.InvalidRead:SchedulerTest.Backup:ResourceManagerTest.SortAndApplyOnAllElementsParallel*:InlineVector*:NeuriteElementBehaviour.*:MechanicalInteraction.*:DiffusionTest.*Convergence*:SimObjectVectorTest.Equality:SchedulerTest::LoadAndBalanceAfterEnvironment)
     add_custom_target(run-valgrind
-    COMMAND  ${CMAKE_BINARY_DIR}/launcher.sh ${CMAKE_SOURCE_DIR}/util/valgrind.sh ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${TEST_TARGET} -- --gtest_filter=-*DeathTest.*:IOTest.InvalidRead:SchedulerTest.Backup:ResourceManagerTest.SortAndApplyOnAllElementsParallel*:InlineVector*:NeuriteElementBehaviour.*:MechanicalInteraction.*:DiffusionTest.*Convergence*)
+    COMMAND  ${CMAKE_BINARY_DIR}/launcher.sh ${CMAKE_SOURCE_DIR}/util/valgrind.sh ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${TEST_TARGET} -- --gtest_filter=-*DeathTest.*:IOTest.InvalidRead:SchedulerTest.Backup:ResourceManagerTest.SortAndApplyOnAllElementsParallel*:InlineVector*:NeuriteElementBehaviour.*:MechanicalInteraction.*:DiffusionTest.*Convergence*:SimObjectVectorTest.Equality:SchedulerTest::LoadAndBalanceAfterEnvironment)
     add_dependencies(run-valgrind biodynamo-unit-tests)
   endif()
 

--- a/src/core/container/sim_object_vector.h
+++ b/src/core/container/sim_object_vector.h
@@ -94,33 +94,6 @@ class SimObjectVector {
     return !this->operator==(other);
   }
 
-  friend std::ostream& operator<<(std::ostream& os,
-                                  const SimObjectVector<T>& sov) {
-    auto* rm = Simulation::GetActive()->GetResourceManager();
-    int nd = 0;
-    os << "{\n";
-    // For each numa domain
-    for (const auto& vec : sov.data_) {
-      os << "Domain " << nd << ": [";
-      int n = 0;
-      auto max = rm->GetNumSimObjects(nd);
-      // For each object in domain `nd` (and remaining extra buffer)
-      for (size_t i = 0; i < vec.capacity(); i++) {
-        os << sov.data_[nd][i];
-        if (n == max - 1) {
-          os << "   |||   ";
-        } else {
-          os << "   |   ";
-        };
-        n++;
-      }
-      os << std::endl;
-      nd++;
-    }
-    os << "\n}";
-    return os;
-  }
-
  private:
   /// one std::vector<T> for each numa node
   std::vector<std::vector<T>> data_;

--- a/src/core/container/sim_object_vector.h
+++ b/src/core/container/sim_object_vector.h
@@ -74,6 +74,53 @@ class SimObjectVector {
     return data_[handle.GetNumaNode()][handle.GetElementIdx()];
   }
 
+  bool operator==(const SimObjectVector<T>& other) const {
+    if (size_ != other.size_) {
+      return false;
+    }
+    // inline data
+    for (size_t i = 0; i < size_.size(); i++) {
+      auto sz = size_[i];
+      for (size_t j = 0; j < sz; j++) {
+        if (data_[i][j] != other.data_[i][j]) {
+          return false;
+        }
+      }
+    }
+    return true;
+  }
+
+  bool operator!=(const SimObjectVector<T>& other) const {
+    return !this->operator==(other);
+  }
+
+  friend std::ostream& operator<<(std::ostream& os,
+                                  const SimObjectVector<T>& sov) {
+    auto* rm = Simulation::GetActive()->GetResourceManager();
+    int nd = 0;
+    os << "{\n";
+    // For each numa domain
+    for (const auto& vec : sov.data_) {
+      os << "Domain " << nd << ": [";
+      int n = 0;
+      auto max = rm->GetNumSimObjects(nd);
+      // For each object in domain `nd` (and remaining extra buffer)
+      for (size_t i = 0; i < vec.capacity(); i++) {
+        os << sov.data_[nd][i];
+        if (n == max - 1) {
+          os << "   |||   ";
+        } else {
+          os << "   |   ";
+        };
+        n++;
+      }
+      os << std::endl;
+      nd++;
+    }
+    os << "\n}";
+    return os;
+  }
+
  private:
   /// one std::vector<T> for each numa node
   std::vector<std::vector<T>> data_;

--- a/src/core/environment/uniform_grid_environment.h
+++ b/src/core/environment/uniform_grid_environment.h
@@ -55,6 +55,7 @@ class UniformGridEnvironment : public Environment {
   // the grid on GPU (same for DisplacementOpOpenCL)
   friend struct DisplacementOpCuda;
   friend struct DisplacementOpOpenCL;
+  friend class SchedulerTest;
 
  public:
   /// A single unit cube of the grid

--- a/src/core/operation/load_balancing_op.h
+++ b/src/core/operation/load_balancing_op.h
@@ -21,13 +21,14 @@
 
 namespace bdm {
 
-/// A class that sets up diffusion grids of the substances in this simulation
+/// A operation that balances the simulation objects among the available NUMA
+/// domains in order to minimize crosstalk. This operation invalidates the
+/// SoHandles in the ResourceManager
 struct LoadBalancingOp : public StandaloneOperationImpl {
   BDM_OP_HEADER(LoadBalancingOp);
 
   void operator()() override {
-    auto* sim = Simulation::GetActive();
-    auto* rm = sim->GetResourceManager();
+    auto* rm = Simulation::GetActive()->GetResourceManager();
     rm->SortAndBalanceNumaNodes();
   }
 };

--- a/src/core/operation/operation.cc
+++ b/src/core/operation/operation.cc
@@ -48,11 +48,7 @@ void Operation::operator()(SimObject *so) {
   (*implementations_[active_target_])(so);
 }
 
-void Operation::operator()() {
-  if (standalone_enabled_) {
-    (*implementations_[active_target_])();
-  }
-}
+void Operation::operator()() { (*implementations_[active_target_])(); }
 
 void Operation::AddOperationImpl(OpComputeTarget target, OperationImpl *impl) {
   if (implementations_.size() < static_cast<size_t>(target + 1)) {

--- a/src/core/operation/operation.h
+++ b/src/core/operation/operation.h
@@ -181,10 +181,6 @@ struct Operation {
   OpComputeTarget active_target_ = kCpu;
   /// The different operation implementations for each supported compute target
   std::vector<OperationImpl *> implementations_;
-  /// Flag to determine if an operation should be executable in stand-alone mode
-  /// This can be useful for enabling / disabling of outstanding operations
-  /// in Scheduler
-  bool standalone_enabled_ = true;
 };
 
 }  // namespace bdm

--- a/src/core/scheduler.cc
+++ b/src/core/scheduler.cc
@@ -41,40 +41,51 @@ Scheduler::Scheduler() {
 
   // Operations are scheduled in the following order (sub categorated by their
   // operation implementation type, so that actual order may vary)
-  std::vector<std::string> default_ops = {"update run displacement",
-                                          "bound space",
-                                          "biology module",
-                                          "displacement",
-                                          "discretization",
-                                          "distribute run displacement info",
-                                          "diffusion"};
+  std::vector<std::string> default_op_names = {
+      "update run displacement",
+      "bound space",
+      "biology module",
+      "displacement",
+      "discretization",
+      "distribute run displacement info",
+      "diffusion"};
+
+  std::vector<std::string> pre_scheduled_ops_names = {"set up iteration", 
+                                                      "update environment"};
+  // We cannot put sort and balance in the list of scheduled_standalone_ops_,
+  // because numa-aware data structures would be invalidated:
+  // ```
+  //  SetUpOps() <-- (1)
+  //  RunScheduledOps() <-- rebalance numa domains
+  //  TearDownOps() <-- indexing with SoHandles is different than at (1)
+  // ```
+  std::vector<std::string> post_scheduled_ops_names = {
+      "visualize", "load balancing", "tear down iteration"};
 
   // Schedule the default operations
-  for (auto& def_op : default_ops) {
-    ScheduleOp(NewOperation(def_op));
+  for (auto& def_op : default_op_names) {
+    ScheduleOp(NewOperation(def_op), OpType::kSchedule);
   }
 
-  visualize_op_ = NewOperation("visualize");
-  setup_iteration_op_ = NewOperation("set up iteration");
-  sort_balance_op_ = NewOperation("load balancing");
-  teardown_iteration_op_ = NewOperation("tear down iteration");
-  update_environment_op_ = NewOperation("update environment");
+  for (auto& def_op : pre_scheduled_ops_names) {
+    ScheduleOp(NewOperation(def_op), OpType::kPreSchedule);
+  }
 
-  outstanding_operations_ = {"load balancing", "visualize"};
+  for (auto& def_op : post_scheduled_ops_names) {
+    ScheduleOp(NewOperation(def_op), OpType::kPostSchedule);
+  }
 
-  protected_ops_ = {"update run displacement", "biology module",
-                    "discretization", "distribute run displacment info"};
+  protected_op_names_ = {
+      "update run displacement", "biology module",
+      "discretization",          "distribute run displacment info",
+      "set up iteration",        "update environment",
+      "tear down iteration"};
 }
 
 Scheduler::~Scheduler() {
   for (auto* op : all_ops_) {
     delete op;
   }
-  delete visualize_op_;
-  delete sort_balance_op_;
-  delete update_environment_op_;
-  delete setup_iteration_op_;
-  delete teardown_iteration_op_;
   delete backup_;
   delete root_visualization_;
 }
@@ -97,15 +108,20 @@ uint64_t Scheduler::GetSimulatedSteps() const { return total_steps_; }
 
 TimingAggregator* Scheduler::GetOpTimes() { return &op_times_; }
 
-void Scheduler::ScheduleOp(Operation* op) {
-  all_ops_.push_back(op);
-  ops_to_add_.push_back(op);
+void Scheduler::ScheduleOp(Operation* op, OpType op_type) {
+  // Check if operation is already in all_ops_ (could be the case when
+  // trying to reschedule a previously unscheduled operation)
+  if (std::find(all_ops_.begin(), all_ops_.end(), op) == all_ops_.end()) {
+    all_ops_.push_back(op);
+  }
+
+  schedule_ops_.push_back(std::make_pair(op_type, op));
 }
 
 void Scheduler::UnscheduleOp(Operation* op) {
   // We must not unschedule a protected operation
-  if (std::find(protected_ops_.begin(), protected_ops_.end(), op->name_) !=
-      protected_ops_.end()) {
+  if (std::find(protected_op_names_.begin(), protected_op_names_.end(),
+                op->name_) != protected_op_names_.end()) {
     Log::Warning("Scheduler::UnscheduleOp",
                  "You tried to unschedule the protected operation ", op->name_,
                  "! This request was ignored.");
@@ -127,13 +143,7 @@ void Scheduler::UnscheduleOp(Operation* op) {
     return;
   }
 
-  // 'Unschedule' outstanding operations
-  if (std::find(outstanding_operations_.begin(), outstanding_operations_.end(),
-                op->name_) != outstanding_operations_.end()) {
-    op->standalone_enabled_ = false;
-  }
-
-  ops_to_remove_.push_back(op);
+  unschedule_ops_.push_back(op);
 }
 
 std::vector<std::string> Scheduler::GetListOfScheduledSimObjectOps() const {
@@ -154,8 +164,10 @@ std::vector<std::string> Scheduler::GetListOfScheduledStandaloneOps() const {
 
 std::vector<Operation*> Scheduler::GetOps(const std::string& name) {
   std::vector<Operation*> ret;
-  if (std::find(protected_ops_.begin(), protected_ops_.end(), name) !=
-      protected_ops_.end()) {
+
+  // Check if a protected op is trying to be fetched
+  if (std::find(protected_op_names_.begin(), protected_op_names_.end(), name) !=
+      protected_op_names_.end()) {
     Log::Warning("Scheduler::GetOps", "The operation '", name,
                  "' is a protected operation. Request ignored.");
     return ret;
@@ -200,11 +212,21 @@ void Scheduler::TearDownOps() {
   });
 }
 
+void Scheduler::RunPreScheduledOps() {
+  for (auto* pre_op : pre_scheduled_ops_) {
+    if (total_steps_ % pre_op->frequency_ == 0) {
+      Timing::Time(pre_op->name_, [&]() { (*pre_op)(); });
+    }
+  }
+}
+
 void Scheduler::RunScheduledOps() {
   auto* sim = Simulation::GetActive();
   auto* rm = sim->GetResourceManager();
   auto* param = sim->GetParam();
   auto batch_size = param->scheduling_batch_size_;
+
+  SetUpOps();
 
   // Run the sim object operations
   std::vector<Operation*> sim_object_ops;
@@ -225,39 +247,24 @@ void Scheduler::RunScheduledOps() {
       Timing::Time(op->name_, [&]() { (*op)(); });
     }
   }
+
+  TearDownOps();
+}
+
+void Scheduler::RunPostScheduledOps() {
+  for (auto* post_op : post_scheduled_ops_) {
+    if (total_steps_ % post_op->frequency_ == 0) {
+      Timing::Time(post_op->name_, [&]() { (*post_op)(); });
+    }
+  }
 }
 
 void Scheduler::Execute() {
   ScheduleOps();
-  Timing::Time(setup_iteration_op_->name_, [&]() { (*setup_iteration_op_)(); });
 
-  // We cannot put sort and balance in the list of scheduled_standalone_ops_,
-  // because numa-aware data structures would be invalidated:
-  // ```
-  //  SetUpOps() <-- (1)
-  //  RunScheduledOps() <-- rebalance numa domains
-  //  TearDownOps() <-- indexing with SoHandles are different than at (1)
-  // ```
-  if (total_steps_ % sort_balance_op_->frequency_ == 0) {
-    Timing::Time(sort_balance_op_->name_, [&]() { (*sort_balance_op_)(); });
-  }
-
-  // We need to update the environment BEFORE setting up the operations, as
-  // some operations depend on the grid members to be up to date (e.g. GPU
-  // displacement operation)
-  Timing::Time(update_environment_op_->name_,
-               [&]() { (*update_environment_op_)(); });
-
-  SetUpOps();
+  RunPreScheduledOps();
   RunScheduledOps();
-  TearDownOps();
-
-  Timing::Time(teardown_iteration_op_->name_,
-               [&]() { (*teardown_iteration_op_)(); });
-
-  if (total_steps_ % visualize_op_->frequency_ == 0) {
-    Timing::Time(visualize_op_->name_, [&]() { (*visualize_op_)(); });
-  }
+  RunPostScheduledOps();
 }
 
 void Scheduler::Backup() {
@@ -326,8 +333,10 @@ void Scheduler::Initialize() {
 void Scheduler::ScheduleOps() {
   auto* param = Simulation::GetActive()->GetParam();
   // Add requested operations
-  for (auto it = ops_to_add_.begin(); it != ops_to_add_.end();) {
-    auto* op = *it;
+  for (auto it = schedule_ops_.begin(); it != schedule_ops_.end();) {
+    auto op_type = it->first;
+    auto* op = it->second;
+
     // Enable GPU operation implementations (if available) if CUDA or OpenCL
     // flags are set
     if (param->compute_target_ == "cuda" &&
@@ -340,42 +349,45 @@ void Scheduler::ScheduleOps() {
       op->SelectComputeTarget(kCpu);
     }
 
-    if (op->IsStandalone()) {
-      scheduled_standalone_ops_.push_back(op);
-    } else {
-      scheduled_sim_object_ops_.push_back(op);
+    // Check operation type and append to corresponding list
+    switch (op_type) {
+      case kPreSchedule:
+        pre_scheduled_ops_.push_back(op);
+        break;
+      case kPostSchedule:
+        post_scheduled_ops_.push_back(op);
+        break;
+      default:
+        if (op->IsStandalone()) {
+          scheduled_standalone_ops_.push_back(op);
+        } else {
+          scheduled_sim_object_ops_.push_back(op);
+        }
     }
 
-    // Remove operation from ops_to_add_
-    it = ops_to_add_.erase(it);
+    // Remove operation from schedule_ops_
+    it = schedule_ops_.erase(it);
   }
 
-  // Remove requested operations
-  for (auto it = ops_to_remove_.begin(); it != ops_to_remove_.end();) {
+  // Unschedule requested operations
+  for (auto it = unschedule_ops_.begin(); it != unschedule_ops_.end();) {
     auto* op = *it;
-    // Check scheduled row-wise operations list
-    for (auto it2 = scheduled_sim_object_ops_.begin();
-         it2 != scheduled_sim_object_ops_.end(); ++it2) {
-      if (op == (*it2)) {
-        // Add to list of unscheduled operations
-        unscheduled_ops_.push_back(op);
-        it2 = scheduled_sim_object_ops_.erase(it2);
-        goto label;
-      }
-    }
 
-    // Check scheduled column-wise operations list
-    for (auto it2 = scheduled_standalone_ops_.begin();
-         it2 != scheduled_standalone_ops_.end(); ++it2) {
-      if (op == (*it2)) {
-        // Add to list of unscheduled operations
-        unscheduled_ops_.push_back(op);
-        it2 = scheduled_standalone_ops_.erase(it2);
-        goto label;
+    // Lists of operations that should be considered for unscheduling
+    std::vector<std::vector<Operation*>*> op_lists = {
+        &scheduled_sim_object_ops_, &scheduled_standalone_ops_,
+        &pre_scheduled_ops_, &post_scheduled_ops_};
+
+    for (auto* op_list : op_lists) {
+      for (auto it2 = op_list->begin(); it2 != op_list->end(); ++it2) {
+        if (op == (*it2)) {
+          it2 = op_list->erase(it2);
+          goto label;
+        }
       }
     }
   label:
-    it = ops_to_remove_.erase(it);
+    it = unschedule_ops_.erase(it);
   }
 }
 

--- a/src/core/scheduler.cc
+++ b/src/core/scheduler.cc
@@ -60,7 +60,7 @@ Scheduler::Scheduler() {
   //  TearDownOps() <-- indexing with SoHandles is different than at (1)
   // ```
   std::vector<std::string> post_scheduled_ops_names = {
-      "visualize", "load balancing", "tear down iteration"};
+      "tear down iteration", "visualize", "load balancing"};
 
   // Schedule the default operations
   for (auto& def_op : default_op_names) {

--- a/src/core/scheduler.h
+++ b/src/core/scheduler.h
@@ -27,6 +27,7 @@
 
 namespace bdm {
 
+class SchedulerTest;
 class SimObject;
 class SimulationBackup;
 class VisualizationAdaptor;
@@ -34,6 +35,8 @@ class RootAdaptor;
 struct BoundSpace;
 struct DisplacementOp;
 struct DiffusionOp;
+
+enum OpType { kSchedule, kPreSchedule, kPostSchedule };
 
 class Scheduler {
  public:
@@ -45,6 +48,8 @@ class Scheduler {
 
   void Simulate(uint64_t steps);
 
+  Operation* NewOutstandingOperation(const std::string& name);
+
   /// This function returns the numer of simulated steps (=iterations).
   uint64_t GetSimulatedSteps() const;
 
@@ -52,7 +57,7 @@ class Scheduler {
   /// operations.
   /// Scheduler takes over ownership of the object `op`.
   /// NB: Don't pass stack objects to this function.
-  void ScheduleOp(Operation* op);
+  void ScheduleOp(Operation* op, OpType op_type = OpType::kSchedule);
 
   void UnscheduleOp(Operation* op);
 
@@ -61,15 +66,28 @@ class Scheduler {
   /// function returns an empty vector.
   std::vector<Operation*> GetOps(const std::string& name);
 
+  /// Runs a lambda for each operation in the specified list of operations
+  template <typename Lambda>
+  void ForAllOperationsInList(const std::vector<Operation*>& operations,
+                              Lambda lambda) {
+    for (auto* op : operations) {
+      lambda(op);
+    }
+  }
+
+  /// Runs a lambda for each scheduled operation
   template <typename Lambda>
   void ForAllScheduledOperations(Lambda lambda) {
-    for (auto* op : scheduled_sim_object_ops_) {
-      lambda(op);
-    }
+    ForAllOperationsInList(scheduled_sim_object_ops_, lambda);
+    ForAllOperationsInList(scheduled_standalone_ops_, lambda);
+  }
 
-    for (auto* op : scheduled_standalone_ops_) {
-      lambda(op);
-    }
+  /// Runs a lambda for each operation that is executed in the Execute() call
+  template <typename Lambda>
+  void ForAllOperations(Lambda lambda) {
+    ForAllScheduledOperations(lambda);
+    ForAllOperationsInList(pre_scheduled_ops_, lambda);
+    ForAllOperationsInList(post_scheduled_ops_, lambda);
   }
 
   /// Return a list of SimObjectOperations that are scheduled
@@ -78,11 +96,19 @@ class Scheduler {
   /// Return a list of StandAloneOperations that are scheduled
   std::vector<std::string> GetListOfScheduledStandaloneOps() const;
 
+  // Run the Operation::SetUp() call for each scheduled operation
   void SetUpOps();
 
   void TearDownOps();
 
+  // Run the operations in scheduled_*_ops_
   void RunScheduledOps();
+
+  // Run the operations in pre_scheduled_ops_ (executed before RunScheduledOps)
+  void RunPreScheduledOps();
+
+  // Run the operations in post_scheduled_ops_ (executed after RunScheduledOps)
+  void RunPostScheduledOps();
 
   void ScheduleOps();
 
@@ -98,6 +124,8 @@ class Scheduler {
   virtual void Execute();
 
  private:
+  friend SchedulerTest;
+
   SimulationBackup* backup_ = nullptr;
   uint64_t restore_point_;
   std::chrono::time_point<Clock> last_backup_ = Clock::now();
@@ -109,21 +137,21 @@ class Scheduler {
   /// list.
   std::vector<Operation*> all_ops_;  //!
   /// List of operations that are to be added in the upcoming timestep
-  std::vector<Operation*> ops_to_add_;  //!
+  std::vector<std::pair<OpType, Operation*>> schedule_ops_;  //!
   /// List of operations that are to be removed in the upcoming timestep
-  std::vector<Operation*> ops_to_remove_;  //!
-  /// List of operations that were removed from scheduling, but could be reused
-  /// later on in a simulation
-  std::vector<Operation*> unscheduled_ops_;  //!
+  std::vector<Operation*> unschedule_ops_;  //!
   /// List of operations will be executed as a stand-alone operation
   std::vector<Operation*> scheduled_standalone_ops_;  //!
   /// List of operations will be executed on all simulation objects
   std::vector<Operation*> scheduled_sim_object_ops_;  //!
   /// List of operations that cannot be affected by the user
-  std::vector<std::string> protected_ops_;  //!
-  /// List of operations that cannot be in a scheduled_*_ops_ list, but could be
-  /// unscheduled nevertheless
-  std::vector<std::string> outstanding_operations_;  //!
+  std::vector<std::string> protected_op_names_;  //!
+  // Operations that are run before setting up, running and tearing down
+  // scheduled operations
+  std::vector<Operation*> pre_scheduled_ops_;
+  // Operations that are run after setting up, running and tearing down
+  // scheduled operations
+  std::vector<Operation*> post_scheduled_ops_;
   /// Tracks operations' execution times
   TimingAggregator op_times_;
   Operation* visualize_op_ = nullptr;

--- a/src/core/scheduler.h
+++ b/src/core/scheduler.h
@@ -154,11 +154,6 @@ class Scheduler {
   std::vector<Operation*> post_scheduled_ops_;
   /// Tracks operations' execution times
   TimingAggregator op_times_;
-  Operation* visualize_op_ = nullptr;
-  Operation* update_environment_op_ = nullptr;
-  Operation* sort_balance_op_ = nullptr;
-  Operation* setup_iteration_op_ = nullptr;
-  Operation* teardown_iteration_op_ = nullptr;
 
   /// Backup the simulation. Backup interval based on `Param::backup_interval_`
   void Backup();

--- a/src/core/sim_object/sim_object.h
+++ b/src/core/sim_object/sim_object.h
@@ -218,6 +218,7 @@ class SimObject {
   /// Return simulation object pointer
   template <typename TSimObject = SimObject>
   SoPointer<TSimObject> GetSoPtr() const {
+    static_assert(!std::is_pointer<TSimObject>::value, "Cannot be of pointer type!");
     return SoPointer<TSimObject>(uid_);
   }
 

--- a/test/unit/core/container/sim_object_vector_test.cc
+++ b/test/unit/core/container/sim_object_vector_test.cc
@@ -43,4 +43,36 @@ TEST(SimObjectVectorTest, All) {
   EXPECT_EQ(0u, vector.size(0));
 }
 
+TEST(SimObjectVectorTest, Equality) {
+  std::string sim_name("simulation_object_vector_test_RunInitializerTest2");
+  Simulation simulation(sim_name);
+  auto* rm = simulation.GetResourceManager();
+
+  rm->push_back(new TestSimObject());
+  rm->push_back(new TestSimObject());
+  rm->push_back(new TestSimObject());
+
+  SimObjectVector<int> vec_a;
+  SimObjectVector<int> vec_b;
+  EXPECT_EQ(3u, vec_a.size(0));
+  EXPECT_EQ(3u, vec_b.size(0));
+
+  // values are not initialized
+  vec_a[SoHandle(0, 0)] = 1;
+  vec_a[SoHandle(0, 1)] = 2;
+  vec_a[SoHandle(0, 2)] = 3;
+
+  EXPECT_NE(vec_a, vec_b);
+
+  vec_b[SoHandle(0, 0)] = 1;
+  vec_b[SoHandle(0, 1)] = 2;
+  vec_b[SoHandle(0, 2)] = 3;
+
+  EXPECT_EQ(vec_a, vec_b);
+
+  vec_a.clear();
+  vec_b.clear();
+  EXPECT_EQ(vec_a, vec_b);
+}
+
 }  // namespace bdm

--- a/test/unit/core/operation/operation_test.cc
+++ b/test/unit/core/operation/operation_test.cc
@@ -53,8 +53,8 @@ TEST(OperationTest, SetupTearDown) {
 
   auto* op_impl = op->GetImplementation<OperationTestOp>();
 
-  EXPECT_EQ(op_impl->setup_counter_, 5);
-  EXPECT_EQ(op_impl->teardown_counter_, 5);
+  EXPECT_EQ(5, op_impl->setup_counter_);
+  EXPECT_EQ(5, op_impl->teardown_counter_);
 }
 
 struct CheckDiameter : public Functor<void, SimObject*, int*> {
@@ -92,15 +92,13 @@ struct CheckXPosition : public Functor<void, SimObject*, double*> {
 TEST(OperationTest, ReductionOp) {
   // Lower the batch size such that multiple threads are working in parallel on
   // the operations (to test if multithreading doesn't cause race conditions)
-  auto set_param = [](Param* param) {
-    param->scheduling_batch_size_ = 3;
-  };
+  auto set_param = [](Param* param) { param->scheduling_batch_size_ = 3; };
   Simulation simulation("", set_param);
   auto* scheduler = simulation.GetScheduler();
 
   auto construct = [&](const Double3& position) {
     Cell* cell = new Cell(position);
-    cell->SetDiameter(1 + position[0]/10);
+    cell->SetDiameter(1 + position[0] / 10);
     return cell;
   };
   ModelInitializer::Grid3D(3, 50, construct);
@@ -137,9 +135,7 @@ TEST(OperationTest, ReductionOp) {
 TEST(OperationTest, ReductionOpMultiThreading) {
   // Lower the batch size such that multiple threads are working in parallel on
   // the operations (to test if multithreading doesn't cause race conditions)
-  auto set_param = [](Param* param) {
-    param->scheduling_batch_size_ = 3;
-  };
+  auto set_param = [](Param* param) { param->scheduling_batch_size_ = 3; };
   Simulation simulation("", set_param);
   auto* scheduler = simulation.GetScheduler();
 

--- a/test/unit/core/scheduler_test.h
+++ b/test/unit/core/scheduler_test.h
@@ -30,7 +30,6 @@
 #define ROOTFILE "bdmFile.root"
 
 namespace bdm {
-namespace scheduler_test_internal {
 
 class TestSchedulerRestore : public Scheduler {
  public:
@@ -123,7 +122,6 @@ inline void RunBackupTest() {
   remove(ROOTFILE);
 }
 
-}  // namespace scheduler_test_internal
 }  // namespace bdm
 
 #endif  // UNIT_CORE_SCHEDULER_TEST_H_

--- a/test/unit/neuroscience/mechanical_interaction_test.cc
+++ b/test/unit/neuroscience/mechanical_interaction_test.cc
@@ -328,8 +328,8 @@ TEST(MechanicalInteraction, BifurcationCylinderGrowth) {
   }
 
   auto branches = ne->Bifurcate();
-  auto branch_l = branches[0];
-  auto branch_r = branches[1];
+  auto branch_l = branches[0]->GetSoPtr<NeuriteElement>();
+  auto branch_r = branches[1]->GetSoPtr<NeuriteElement>();
 
   for (int i = 0; i < 200; i++) {
     branch_r->ElongateTerminalEnd(100, direction);
@@ -372,7 +372,7 @@ TEST(MechanicalInteraction, BranchCylinderGrowth) {
     scheduler->Simulate(1);
   }
 
-  auto ne2 = ne->Branch(0.5, direction2);
+  auto ne2 = ne->Branch(0.5, direction2)->GetSoPtr<NeuriteElement>();
 
   EXPECT_NEAR(ne_axis[0], 0, abs_error<double>::value);
   EXPECT_NEAR(ne_axis[1], 0, abs_error<double>::value);


### PR DESCRIPTION
* Introduce three types of operations in Scheduler:
     1) PreScheduledOp
     2) ScheduledOp
     3) PostScheduledOp


  There are currently several operations that need to be run
  before (PreScheduledOp) and after (PostScheduledOp) the regular
  operations (ScheduledOp). Instead of having them floating around
  in Scheduler, we create separate lists for each type of operation

  This way, it is possible to schedule, unschedule and reschedule
  any operation using the same interface as we did before

* Load and balancing should be a PostScheduledOp rather than a
  PreScheduleOp (SoHandles could be invalidated). Added a unit test
  for this