### PR TITLE
Improve CUDA code

### DIFF
--- a/src/core/container/agent_vector.h
+++ b/src/core/container/agent_vector.h
@@ -21,10 +21,15 @@
 
 namespace bdm {
 
+namespace detail {
+struct InitializeGPUData;
+}  // namespace detail
+
 /// Two dimensional vector. Holds one element of type `T` for each agent
 /// in the simulation.
 template <typename T>
 class AgentVector {
+  friend struct detail::InitializeGPUData;
   friend struct MechanicalForcesOpCuda;
 
  public:

--- a/src/core/environment/uniform_grid_environment.h
+++ b/src/core/environment/uniform_grid_environment.h
@@ -48,12 +48,17 @@
 
 namespace bdm {
 
+namespace detail {
+struct InitializeGPUData;
+}  // namespace detail
+
 /// A class that represents Cartesian 3D grid
 class UniformGridEnvironment : public Environment {
   // MechanicalForcesOpCuda needs access to some UniformGridEnvironment private
   // members to reconstruct
   // the grid on GPU (same for MechanicalForcesOpOpenCL)
   friend struct MechanicalForcesOpCuda;
+  friend struct ::bdm::detail::InitializeGPUData;
   friend struct MechanicalForcesOpOpenCL;
   friend class SchedulerTest;
 

--- a/src/core/environment/uniform_grid_environment.h
+++ b/src/core/environment/uniform_grid_environment.h
@@ -609,16 +609,15 @@ class UniformGridEnvironment : public Environment {
   /// @tparam     TUint32          A uint32 type (could also be cl_uint)
   /// @tparam     TInt32           A int32 type (could be cl_int)
   ///
-  template <typename TUint32, typename TInt32>
-  void GetGridInfo(TUint32* box_length, std::array<TUint32, 3>* num_boxes_axis,
-                   std::array<TInt32, 3>* grid_dimensions) {
-    box_length[0] = box_length_;
-    (*num_boxes_axis)[0] = num_boxes_axis_[0];
-    (*num_boxes_axis)[1] = num_boxes_axis_[1];
-    (*num_boxes_axis)[2] = num_boxes_axis_[2];
-    (*grid_dimensions)[0] = grid_dimensions_[0];
-    (*grid_dimensions)[1] = grid_dimensions_[2];
-    (*grid_dimensions)[2] = grid_dimensions_[4];
+  void GetGridInfo(uint32_t* box_length, uint32_t* num_boxes_axis,
+                   int32_t* grid_dimensions) {
+    *box_length = box_length_;
+    num_boxes_axis[0] = num_boxes_axis_[0];
+    num_boxes_axis[1] = num_boxes_axis_[1];
+    num_boxes_axis[2] = num_boxes_axis_[2];
+    grid_dimensions[0] = grid_dimensions_[0];
+    grid_dimensions[1] = grid_dimensions_[2];
+    grid_dimensions[2] = grid_dimensions_[4];
   }
 
   // NeighborMutex ---------------------------------------------------------

--- a/src/core/gpu/cuda_error_chk.h
+++ b/src/core/gpu/cuda_error_chk.h
@@ -18,6 +18,7 @@
 #if !defined(__ROOTCLING__) && !defined(G__DICTIONARY)
 #ifdef USE_CUDA
 
+#include <cstdio>
 #include <unistd.h>
 
 #define GpuErrchk(ans) \

--- a/src/core/gpu/cuda_error_chk.h
+++ b/src/core/gpu/cuda_error_chk.h
@@ -18,8 +18,8 @@
 #if !defined(__ROOTCLING__) && !defined(G__DICTIONARY)
 #ifdef USE_CUDA
 
-#include <cstdio>
 #include <unistd.h>
+#include <cstdio>
 
 #define GpuErrchk(ans) \
   { GpuAssert((ans), __FILE__, __LINE__); }

--- a/src/core/gpu/cuda_error_chk.h
+++ b/src/core/gpu/cuda_error_chk.h
@@ -1,0 +1,43 @@
+// -----------------------------------------------------------------------------
+//
+// Copyright (C) The BioDynaMo Project.
+// All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// See the LICENSE file distributed with this work for details.
+// See the NOTICE file distributed with this work for additional information
+// regarding copyright ownership.
+//
+// -----------------------------------------------------------------------------
+
+#ifndef CORE_GPU_CUDA_ERROR_CHK_H_
+#define CORE_GPU_CUDA_ERROR_CHK_H_
+
+#if !defined(__ROOTCLING__) && !defined(G__DICTIONARY)
+#ifdef USE_CUDA
+
+#include <unistd.h>
+
+#define GpuErrchk(ans) \
+  { GpuAssert((ans), __FILE__, __LINE__); }
+inline void GpuAssert(cudaError_t code, const char *file, int line,
+                      bool abort = true) {
+  if (code != cudaSuccess) {
+    fprintf(stderr, "GPUassert (error code %d): %s %s %d\n", code,
+            cudaGetErrorString(code), file, line);
+    if (code == cudaErrorInsufficientDriver) {
+      printf(
+          "This probably means that no CUDA-compatible GPU has been detected. "
+          "Consider setting the use_opencl flag to \"true\" in the bmd.toml "
+          "file to use OpenCL instead.\n");
+    }
+    if (abort)
+      exit(code);
+  }
+}
+
+#endif  // USE_CUDA
+#endif  // !__ROOTCLING__ && !G__DICTIONARY
+#endif  // CORE_GPU_CUDA_ERROR_CHK_H_

--- a/src/core/gpu/cuda_pinned_memory.cu
+++ b/src/core/gpu/cuda_pinned_memory.cu
@@ -1,0 +1,34 @@
+// -----------------------------------------------------------------------------
+//
+// Copyright (C) The BioDynaMo Project.
+// All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// See the LICENSE file distributed with this work for details.
+// See the NOTICE file distributed with this work for additional information
+// regarding copyright ownership.
+//
+// -----------------------------------------------------------------------------
+
+#include "core/gpu/cuda_pinned_memory.h"
+
+namespace bdm {
+
+template <typename T>
+void AllocPinned(T** d, uint64_t elements) {
+  cudaMallocHost((void**)d, elements * sizeof(T));
+}
+
+template void AllocPinned<double>(double**, uint64_t);
+template void AllocPinned<float>(float**, uint64_t);
+template void AllocPinned<uint64_t>(uint64_t**, uint64_t);
+template void AllocPinned<int64_t>(int64_t**, uint64_t);
+template void AllocPinned<uint32_t>(uint32_t**, uint64_t);
+template void AllocPinned<int32_t>(int32_t**, uint64_t);
+template void AllocPinned<uint16_t>(uint16_t**, uint64_t);
+template void AllocPinned<int16_t>(int16_t**, uint64_t);
+
+}  // namespace bdm
+

--- a/src/core/gpu/cuda_pinned_memory.cu
+++ b/src/core/gpu/cuda_pinned_memory.cu
@@ -13,12 +13,13 @@
 // -----------------------------------------------------------------------------
 
 #include "core/gpu/cuda_pinned_memory.h"
+#include "core/gpu/cuda_error_chk.h"
 
 namespace bdm {
 
 template <typename T>
 void CudaAllocPinned(T** d, uint64_t elements) {
-  cudaMallocHost((void**)d, elements * sizeof(T));
+  GpuErrchk(cudaMallocHost((void**)d, elements * sizeof(T)));
 }
 
 template void CudaAllocPinned<double>(double**, uint64_t);
@@ -31,7 +32,7 @@ template void CudaAllocPinned<uint16_t>(uint16_t**, uint64_t);
 template void CudaAllocPinned<int16_t>(int16_t**, uint64_t);
 
 void CudaFreePinned(void* p) {
-  cudaFreeHost(p);
+  GpuErrchk(cudaFreeHost(p));
 }
 
 }  // namespace bdm

--- a/src/core/gpu/cuda_pinned_memory.cu
+++ b/src/core/gpu/cuda_pinned_memory.cu
@@ -17,18 +17,21 @@
 namespace bdm {
 
 template <typename T>
-void AllocPinned(T** d, uint64_t elements) {
+void CudaAllocPinned(T** d, uint64_t elements) {
   cudaMallocHost((void**)d, elements * sizeof(T));
 }
 
-template void AllocPinned<double>(double**, uint64_t);
-template void AllocPinned<float>(float**, uint64_t);
-template void AllocPinned<uint64_t>(uint64_t**, uint64_t);
-template void AllocPinned<int64_t>(int64_t**, uint64_t);
-template void AllocPinned<uint32_t>(uint32_t**, uint64_t);
-template void AllocPinned<int32_t>(int32_t**, uint64_t);
-template void AllocPinned<uint16_t>(uint16_t**, uint64_t);
-template void AllocPinned<int16_t>(int16_t**, uint64_t);
+template void CudaAllocPinned<double>(double**, uint64_t);
+template void CudaAllocPinned<float>(float**, uint64_t);
+template void CudaAllocPinned<uint64_t>(uint64_t**, uint64_t);
+template void CudaAllocPinned<int64_t>(int64_t**, uint64_t);
+template void CudaAllocPinned<uint32_t>(uint32_t**, uint64_t);
+template void CudaAllocPinned<int32_t>(int32_t**, uint64_t);
+template void CudaAllocPinned<uint16_t>(uint16_t**, uint64_t);
+template void CudaAllocPinned<int16_t>(int16_t**, uint64_t);
+
+void CudaFreePinned(void* p) {
+  cudaFreeHost(p);
+}
 
 }  // namespace bdm
-

--- a/src/core/gpu/cuda_pinned_memory.h
+++ b/src/core/gpu/cuda_pinned_memory.h
@@ -30,9 +30,9 @@ void CudaFreePinned(void* p);
 #else
 
 template <typename T>
-void CudaAllocPinned(T** d, uint64_t elements) {}
+inline void CudaAllocPinned(T** d, uint64_t elements) {}
 
-void CudaFreePinned(void* p) {}
+inline void CudaFreePinned(void* p) {}
 
 #endif  // USE_CUDA
 

--- a/src/core/gpu/cuda_pinned_memory.h
+++ b/src/core/gpu/cuda_pinned_memory.h
@@ -1,0 +1,36 @@
+// -----------------------------------------------------------------------------
+//
+// Copyright (C) The BioDynaMo Project.
+// All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// See the LICENSE file distributed with this work for details.
+// See the NOTICE file distributed with this work for additional information
+// regarding copyright ownership.
+//
+// -----------------------------------------------------------------------------
+
+#ifndef CORE_GPU_CUDA_PINNED_MEMORY_H_
+#define CORE_GPU_CUDA_PINNED_MEMORY_H_
+
+#include <cstdint>
+
+namespace bdm {
+
+#ifdef USE_CUDA
+
+template <typename T>
+void AllocPinned(T** d, uint64_t size);
+
+#else
+
+template <typename T>
+void AllocPinned(T** d, uint64_t size) {}
+
+#endif  // USE_CUDA
+
+}  // namespace bdm
+
+#endif  // CORE_GPU_CUDA_PINNED_MEMORY_H_

--- a/src/core/gpu/cuda_pinned_memory.h
+++ b/src/core/gpu/cuda_pinned_memory.h
@@ -21,13 +21,18 @@ namespace bdm {
 
 #ifdef USE_CUDA
 
+/// Allocate number of element T objects on host pinned memory 
 template <typename T>
-void AllocPinned(T** d, uint64_t size);
+void CudaAllocPinned(T** d, uint64_t elements);
+
+void CudaFreePinned(void* p);
 
 #else
 
 template <typename T>
-void AllocPinned(T** d, uint64_t size) {}
+void CudaAllocPinned(T** d, uint64_t elements) {}
+
+void CudaFreePinned(void* p) {}
 
 #endif  // USE_CUDA
 

--- a/src/core/gpu/cuda_pinned_memory.h
+++ b/src/core/gpu/cuda_pinned_memory.h
@@ -21,7 +21,7 @@ namespace bdm {
 
 #ifdef USE_CUDA
 
-/// Allocate number of element T objects on host pinned memory 
+/// Allocate number of element T objects on host pinned memory
 template <typename T>
 void CudaAllocPinned(T** d, uint64_t elements);
 

--- a/src/core/gpu/cuda_timer.h
+++ b/src/core/gpu/cuda_timer.h
@@ -1,0 +1,54 @@
+// -----------------------------------------------------------------------------
+//
+// Copyright (C) The BioDynaMo Project.
+// All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// See the LICENSE file distributed with this work for details.
+// See the NOTICE file distributed with this work for additional information
+// regarding copyright ownership.
+//
+// -----------------------------------------------------------------------------
+
+#ifndef CORE_GPU_CUDA_TIMER_H_
+#define CORE_GPU_CUDA_TIMER_H_
+
+#if !defined(__ROOTCLING__) && !defined(G__DICTIONARY)
+#ifdef USE_CUDA
+
+#include <iostream>
+#include <string>
+
+namespace bdm {
+
+class CudaTimer {
+ public:
+  CudaTimer(std::string name) : name_(name) {
+    cudaEventCreate(&start_);
+    cudaEventCreate(&stop_);
+    cudaEventRecord(start_, 0);
+  }
+
+  ~CudaTimer() {
+    cudaEventRecord(stop_, 0);
+    float duration;
+    cudaEventSynchronize(stop_);
+    cudaEventElapsedTime(&duration, start_, stop_);
+    std::cout << name_ << " " << duration << std::endl;
+    cudaEventDestroy(start_);
+    cudaEventDestroy(stop_);
+  }
+
+ private:
+  cudaEvent_t start_;
+  cudaEvent_t stop_;
+  std::string name_;
+};
+
+}  // namespace bdm
+
+#endif  // USE_CUDA
+#endif  // !__ROOTCLING__ && !G__DICTIONARY
+#endif  // CORE_GPU_CUDA_TIMER_H_

--- a/src/core/gpu/mechanical_forces_op_cuda_kernel.cu
+++ b/src/core/gpu/mechanical_forces_op_cuda_kernel.cu
@@ -364,24 +364,3 @@ bdm::MechanicalForcesOpCudaKernel::~MechanicalForcesOpCudaKernel() {
   cudaFree(d_cell_movements_);
 }
 
-
-void bdm::AllocPinned(double** d, uint64_t size) {
-  cudaMallocHost((void**)d, size * sizeof(double));
-}
-
-void bdm::AllocPinned(uint64_t** d, uint64_t size) {
-  cudaMallocHost((void**)d, size * sizeof(uint64_t));
-}
-
-void bdm::AllocPinned(uint32_t** d, uint64_t size) {
-  cudaMallocHost((void**)d, size * sizeof(uint32_t));
-}
-
-void bdm::AllocPinned(int32_t** d, uint64_t size) {
-  cudaMallocHost((void**)d, size * sizeof(int32_t));
-}
-
-void bdm::AllocPinned(uint16_t** d, uint64_t size) {
-  cudaMallocHost((void**)d, size * sizeof(uint16_t));
-}
-

--- a/src/core/gpu/mechanical_forces_op_cuda_kernel.cu
+++ b/src/core/gpu/mechanical_forces_op_cuda_kernel.cu
@@ -17,6 +17,7 @@
 #include <iostream>
 #include <unistd.h>
 #include "core/gpu/cuda_timer.h"
+#include "core/gpu/cuda_error_chk.h"
 
 void printMemoryUsage() {
   size_t availableMemory, totalMemory, usedMemory;
@@ -27,19 +28,6 @@ void printMemoryUsage() {
             << " total " << totalMemory << std::endl;
 }
 
-
-#define GpuErrchk(ans) { GpuAssert((ans), __FILE__, __LINE__); }
-inline void GpuAssert(cudaError_t code, const char *file, int line, bool abort=true)
-{
-   if (code != cudaSuccess) 
-   {
-      fprintf(stderr,"GPUassert (error code %d): %s %s %d\n", code, cudaGetErrorString(code), file, line);
-      if (code == cudaErrorInsufficientDriver) {
-        printf("This probably means that no CUDA-compatible GPU has been detected. Consider setting the use_opencl flag to \"true\" in the bmd.toml file to use OpenCL instead.\n");
-      }
-      if (abort) exit(code);
-   }
-}
 
 inline __host__ __device__ double norm(double3 &v) {
   return sqrt(v.x*v.x + v.y*v.y + v.z*v.z);

--- a/src/core/gpu/mechanical_forces_op_cuda_kernel.cu
+++ b/src/core/gpu/mechanical_forces_op_cuda_kernel.cu
@@ -301,30 +301,31 @@ void bdm::MechanicalForcesOpCudaKernel::LaunchMechanicalForcesKernel(const doubl
   // printf("[LaunchMechanicalForcesKernel] positions[0] = %f  |  positions[1] = %f\n", positions[0], positions[1]);
 
   {
-    GpuTimer timer("Cuda::CopyToDevice");
-  GpuErrchk(cudaMemcpy(d_positions_, 		positions, 3 * num_objects[0] * sizeof(double), cudaMemcpyHostToDevice));
-  GpuErrchk(cudaMemcpy(d_diameters_, 		diameters, num_objects[0] * sizeof(double), cudaMemcpyHostToDevice));
-  GpuErrchk(cudaMemcpy(d_tractor_force_, 	tractor_force, 3 * num_objects[0] * sizeof(double), cudaMemcpyHostToDevice));
-  GpuErrchk(cudaMemcpy(d_adherence_,     adherence, num_objects[0] * sizeof(double), cudaMemcpyHostToDevice));
-  GpuErrchk(cudaMemcpy(d_box_id_, 		box_id, num_objects[0] * sizeof(uint32_t), cudaMemcpyHostToDevice));
-  GpuErrchk(cudaMemcpy(d_mass_, 				mass, num_objects[0] * sizeof(double), cudaMemcpyHostToDevice));
-  GpuErrchk(cudaMemcpy(d_timestep_, 			timestep, sizeof(double), cudaMemcpyHostToDevice));
-  GpuErrchk(cudaMemcpy(d_max_displacement_,  max_displacement, sizeof(double), cudaMemcpyHostToDevice));
-  GpuErrchk(cudaMemcpy(d_squared_radius_, 	squared_radius, sizeof(double), cudaMemcpyHostToDevice));
-  GpuErrchk(cudaMemcpy(d_num_objects_, 				num_objects, sizeof(uint32_t), cudaMemcpyHostToDevice));
-  GpuErrchk(cudaMemcpy(d_starts_, 			starts, num_boxes * sizeof(uint32_t), cudaMemcpyHostToDevice));
-  GpuErrchk(cudaMemcpy(d_lengths_, 			lengths, num_boxes * sizeof(uint16_t), cudaMemcpyHostToDevice));
-  GpuErrchk(cudaMemcpy(d_timestamps_, 			timestamps, num_boxes * sizeof(uint64_t), cudaMemcpyHostToDevice));
-  GpuErrchk(cudaMemcpy(d_current_timestamp_, 			current_timestamp, sizeof(uint64_t), cudaMemcpyHostToDevice));
-  GpuErrchk(cudaMemcpy(d_successors_, 		successors, num_objects[0] * sizeof(uint32_t), cudaMemcpyHostToDevice));
-  GpuErrchk(cudaMemcpy(d_box_length_, 		box_length, sizeof(uint32_t), cudaMemcpyHostToDevice));
-  GpuErrchk(cudaMemcpy(d_num_boxes_axis_, 	num_boxes_axis, 3 * sizeof(uint32_t), cudaMemcpyHostToDevice));
-  GpuErrchk(cudaMemcpy(d_grid_dimensions_, 	grid_dimensions, 3 * sizeof(uint32_t), cudaMemcpyHostToDevice));
+    // GpuTimer timer("Cuda::CopyToDevice");
+  GpuErrchk(cudaMemcpyAsync(d_positions_, 		positions, 3 * num_objects[0] * sizeof(double), cudaMemcpyHostToDevice));
+  GpuErrchk(cudaMemcpyAsync(d_diameters_, 		diameters, num_objects[0] * sizeof(double), cudaMemcpyHostToDevice));
+  GpuErrchk(cudaMemcpyAsync(d_tractor_force_, 	tractor_force, 3 * num_objects[0] * sizeof(double), cudaMemcpyHostToDevice));
+  GpuErrchk(cudaMemcpyAsync(d_adherence_,     adherence, num_objects[0] * sizeof(double), cudaMemcpyHostToDevice));
+  GpuErrchk(cudaMemcpyAsync(d_box_id_, 		box_id, num_objects[0] * sizeof(uint32_t), cudaMemcpyHostToDevice));
+  GpuErrchk(cudaMemcpyAsync(d_mass_, 				mass, num_objects[0] * sizeof(double), cudaMemcpyHostToDevice));
+  GpuErrchk(cudaMemcpyAsync(d_timestep_, 			timestep, sizeof(double), cudaMemcpyHostToDevice));
+  GpuErrchk(cudaMemcpyAsync(d_max_displacement_,  max_displacement, sizeof(double), cudaMemcpyHostToDevice));
+  GpuErrchk(cudaMemcpyAsync(d_squared_radius_, 	squared_radius, sizeof(double), cudaMemcpyHostToDevice));
+  GpuErrchk(cudaMemcpyAsync(d_num_objects_, 				num_objects, sizeof(uint32_t), cudaMemcpyHostToDevice));
+  GpuErrchk(cudaMemcpyAsync(d_starts_, 			starts, num_boxes * sizeof(uint32_t), cudaMemcpyHostToDevice));
+  GpuErrchk(cudaMemcpyAsync(d_lengths_, 			lengths, num_boxes * sizeof(uint16_t), cudaMemcpyHostToDevice));
+  GpuErrchk(cudaMemcpyAsync(d_timestamps_, 			timestamps, num_boxes * sizeof(uint64_t), cudaMemcpyHostToDevice));
+  GpuErrchk(cudaMemcpyAsync(d_current_timestamp_, 			current_timestamp, sizeof(uint64_t), cudaMemcpyHostToDevice));
+  GpuErrchk(cudaMemcpyAsync(d_successors_, 		successors, num_objects[0] * sizeof(uint32_t), cudaMemcpyHostToDevice));
+  GpuErrchk(cudaMemcpyAsync(d_box_length_, 		box_length, sizeof(uint32_t), cudaMemcpyHostToDevice));
+  GpuErrchk(cudaMemcpyAsync(d_num_boxes_axis_, 	num_boxes_axis, 3 * sizeof(uint32_t), cudaMemcpyHostToDevice));
+  GpuErrchk(cudaMemcpyAsync(d_grid_dimensions_, 	grid_dimensions, 3 * sizeof(uint32_t), cudaMemcpyHostToDevice));
   }
 
   int blockSize = 128;
   int minGridSize;
   int gridSize;
+  // cudaDeviceSynchronize();
 
   // Get a near-optimal occupancy with the following thread organization
   cudaOccupancyMaxPotentialBlockSize(&minGridSize, &blockSize, collide, 0, num_objects[0]);
@@ -334,7 +335,7 @@ void bdm::MechanicalForcesOpCudaKernel::LaunchMechanicalForcesKernel(const doubl
 
   // printf("gridSize = %d  |  blockSize = %d\n", gridSize, blockSize);
   {
-    GpuTimer timer("Cuda::Kernel");
+    // GpuTimer timer("Cuda::Kernel");
   collide<<<gridSize, blockSize>>>(d_positions_, d_diameters_, d_tractor_force_,
     d_adherence_, d_box_id_, d_mass_, d_timestep_, d_max_displacement_,
     d_squared_radius_, d_num_objects_, d_starts_, d_lengths_, d_timestamps_,
@@ -342,10 +343,14 @@ void bdm::MechanicalForcesOpCudaKernel::LaunchMechanicalForcesKernel(const doubl
     d_grid_dimensions_, d_cell_movements_);
 
   // We need to wait for the kernel to finish before reading back the result
-  cudaDeviceSynchronize();
+  // cudaDeviceSynchronize();
   }
-    GpuTimer timer("Cuda::CopyToHost");
-  cudaMemcpy(cell_movements, d_cell_movements_, 3 * num_objects[0] * sizeof(double), cudaMemcpyDeviceToHost);
+    // GpuTimer timer("Cuda::CopyToHost");
+  cudaMemcpyAsync(cell_movements, d_cell_movements_, 3 * num_objects[0] * sizeof(double), cudaMemcpyDeviceToHost);
+}
+
+void bdm::MechanicalForcesOpCudaKernel::Synch() const {
+  cudaDeviceSynchronize();
 }
 
 void bdm::MechanicalForcesOpCudaKernel::ResizeCellBuffers(uint32_t num_cells) {
@@ -398,3 +403,25 @@ bdm::MechanicalForcesOpCudaKernel::~MechanicalForcesOpCudaKernel() {
   cudaFree(d_grid_dimensions_);
   cudaFree(d_cell_movements_);
 }
+
+
+void bdm::AllocPinned(double** d, uint64_t size) {
+  cudaMallocHost((void**)d, size * sizeof(double));
+}
+
+void bdm::AllocPinned(uint64_t** d, uint64_t size) {
+  cudaMallocHost((void**)d, size * sizeof(uint64_t));
+}
+
+void bdm::AllocPinned(uint32_t** d, uint64_t size) {
+  cudaMallocHost((void**)d, size * sizeof(uint32_t));
+}
+
+void bdm::AllocPinned(int32_t** d, uint64_t size) {
+  cudaMallocHost((void**)d, size * sizeof(int32_t));
+}
+
+void bdm::AllocPinned(uint16_t** d, uint64_t size) {
+  cudaMallocHost((void**)d, size * sizeof(uint16_t));
+}
+

--- a/src/core/gpu/mechanical_forces_op_cuda_kernel.h
+++ b/src/core/gpu/mechanical_forces_op_cuda_kernel.h
@@ -62,12 +62,6 @@ class MechanicalForcesOpCudaKernel {
   int32_t* d_grid_dimensions_ = nullptr;
 };
 
-void AllocPinned(double** d, uint64_t size);
-void AllocPinned(uint64_t** d, uint64_t size);
-void AllocPinned(uint32_t** d, uint64_t size);
-void AllocPinned(int32_t** d, uint64_t size);
-void AllocPinned(uint16_t** d, uint64_t size);
-
 }  // namespace bdm
 
 #endif  // CORE_GPU_MECHANICAL_FORCES_OP_CUDA_KERNEL_H_

--- a/src/core/gpu/mechanical_forces_op_cuda_kernel.h
+++ b/src/core/gpu/mechanical_forces_op_cuda_kernel.h
@@ -40,6 +40,7 @@ class MechanicalForcesOpCudaKernel {
   void ResizeCellBuffers(uint32_t num_cells);
   void ResizeGridBuffers(uint32_t num_boxes);
 
+#ifndef USE_CUDA
  private:
   double* d_positions_ = nullptr;
   double* d_diameters_ = nullptr;
@@ -60,6 +61,7 @@ class MechanicalForcesOpCudaKernel {
   uint32_t* d_box_length_ = nullptr;
   uint32_t* d_num_boxes_axis_ = nullptr;
   int32_t* d_grid_dimensions_ = nullptr;
+#endif  // USE_CUDA
 };
 
 #ifndef USE_CUDA

--- a/src/core/gpu/mechanical_forces_op_cuda_kernel.h
+++ b/src/core/gpu/mechanical_forces_op_cuda_kernel.h
@@ -36,6 +36,7 @@ class MechanicalForcesOpCudaKernel {
       uint32_t* box_length, uint32_t* num_boxes_axis, int32_t* grid_dimensions,
       double* cell_movements);
 
+  void Synch() const;
   void ResizeCellBuffers(uint32_t num_cells);
   void ResizeGridBuffers(uint32_t num_boxes);
 
@@ -60,6 +61,12 @@ class MechanicalForcesOpCudaKernel {
   uint32_t* d_num_boxes_axis_ = nullptr;
   int32_t* d_grid_dimensions_ = nullptr;
 };
+
+void AllocPinned(double** d, uint64_t size);
+void AllocPinned(uint64_t** d, uint64_t size);
+void AllocPinned(uint32_t** d, uint64_t size);
+void AllocPinned(int32_t** d, uint64_t size);
+void AllocPinned(uint16_t** d, uint64_t size);
 
 }  // namespace bdm
 

--- a/src/core/gpu/mechanical_forces_op_cuda_kernel.h
+++ b/src/core/gpu/mechanical_forces_op_cuda_kernel.h
@@ -40,7 +40,7 @@ class MechanicalForcesOpCudaKernel {
   void ResizeCellBuffers(uint32_t num_cells);
   void ResizeGridBuffers(uint32_t num_boxes);
 
-#ifndef USE_CUDA
+#ifdef USE_CUDA
  private:
   double* d_positions_ = nullptr;
   double* d_diameters_ = nullptr;

--- a/src/core/gpu/mechanical_forces_op_cuda_kernel.h
+++ b/src/core/gpu/mechanical_forces_op_cuda_kernel.h
@@ -62,6 +62,31 @@ class MechanicalForcesOpCudaKernel {
   int32_t* d_grid_dimensions_ = nullptr;
 };
 
+#ifndef USE_CUDA
+// Empty implementaiton if CUDA is not used to avoid undefined reference linking
+// error.
+//
+MechanicalForcesOpCudaKernel::MechanicalForcesOpCudaKernel(uint32_t num_objects,
+                                                           uint32_t num_boxes) {
+}
+MechanicalForcesOpCudaKernel::~MechanicalForcesOpCudaKernel() {}
+
+void MechanicalForcesOpCudaKernel::LaunchMechanicalForcesKernel(
+    const double* positions, const double* diameter,
+    const double* tractor_force, const double* adherence,
+    const uint32_t* box_id, const double* mass, const double* timestep,
+    const double* max_displacement, const double* squared_radius,
+    const uint32_t* num_objects, uint32_t* starts, uint16_t* lengths,
+    uint64_t* timestamps, uint64_t* current_timestamp, uint32_t* successors,
+    uint32_t* box_length, uint32_t* num_boxes_axis, int32_t* grid_dimensions,
+    double* cell_movements) {}
+
+void MechanicalForcesOpCudaKernel::Synch() const {}
+void MechanicalForcesOpCudaKernel::ResizeCellBuffers(uint32_t num_cells) {}
+void MechanicalForcesOpCudaKernel::ResizeGridBuffers(uint32_t num_boxes) {}
+
+#endif  // USE_CUDA
+
 }  // namespace bdm
 
 #endif  // CORE_GPU_MECHANICAL_FORCES_OP_CUDA_KERNEL_H_

--- a/src/core/gpu/mechanical_forces_op_cuda_kernel.h
+++ b/src/core/gpu/mechanical_forces_op_cuda_kernel.h
@@ -66,12 +66,11 @@ class MechanicalForcesOpCudaKernel {
 // Empty implementaiton if CUDA is not used to avoid undefined reference linking
 // error.
 //
-MechanicalForcesOpCudaKernel::MechanicalForcesOpCudaKernel(uint32_t num_objects,
-                                                           uint32_t num_boxes) {
-}
-MechanicalForcesOpCudaKernel::~MechanicalForcesOpCudaKernel() {}
+inline MechanicalForcesOpCudaKernel::MechanicalForcesOpCudaKernel(
+    uint32_t num_objects, uint32_t num_boxes) {}
+inline MechanicalForcesOpCudaKernel::~MechanicalForcesOpCudaKernel() {}
 
-void MechanicalForcesOpCudaKernel::LaunchMechanicalForcesKernel(
+inline void MechanicalForcesOpCudaKernel::LaunchMechanicalForcesKernel(
     const double* positions, const double* diameter,
     const double* tractor_force, const double* adherence,
     const uint32_t* box_id, const double* mass, const double* timestep,
@@ -81,9 +80,11 @@ void MechanicalForcesOpCudaKernel::LaunchMechanicalForcesKernel(
     uint32_t* box_length, uint32_t* num_boxes_axis, int32_t* grid_dimensions,
     double* cell_movements) {}
 
-void MechanicalForcesOpCudaKernel::Synch() const {}
-void MechanicalForcesOpCudaKernel::ResizeCellBuffers(uint32_t num_cells) {}
-void MechanicalForcesOpCudaKernel::ResizeGridBuffers(uint32_t num_boxes) {}
+inline void MechanicalForcesOpCudaKernel::Synch() const {}
+inline void MechanicalForcesOpCudaKernel::ResizeCellBuffers(
+    uint32_t num_cells) {}
+inline void MechanicalForcesOpCudaKernel::ResizeGridBuffers(
+    uint32_t num_boxes) {}
 
 #endif  // USE_CUDA
 

--- a/src/core/operation/mechanical_forces_op_cuda.cc
+++ b/src/core/operation/mechanical_forces_op_cuda.cc
@@ -40,11 +40,11 @@ void IsNonSphericalObjectPresent(const Agent* agent, bool* answer) {
 }
 
 namespace detail {
-  
+
 // -----------------------------------------------------------------------------
 struct InitializeGPUData : public Functor<void, Agent*, AgentHandle> {
   bool is_non_spherical_object = false;
-  
+
   double* cell_movements = nullptr;
   double* cell_positions = nullptr;
   double* cell_diameters = nullptr;
@@ -71,19 +71,19 @@ struct InitializeGPUData : public Functor<void, Agent*, AgentHandle> {
   InitializeGPUData();
 
   virtual ~InitializeGPUData();
-  
+
   void Initialize(uint64_t num_objects, uint64_t num_boxes,
                   const std::vector<AgentHandle::ElementIdx_t>& offs,
                   UniformGridEnvironment* g);
 
   void operator()(Agent* agent, AgentHandle ah) override;
 
-  private:
+ private:
   void FreeAgentBuffers();
 
   void FreeGridBuffers();
 };
-    
+
 // -----------------------------------------------------------------------------
 InitializeGPUData::InitializeGPUData() {}
 
@@ -94,7 +94,7 @@ InitializeGPUData::~InitializeGPUData() {
     CudaFreePinned(box_length);
     CudaFreePinned(num_boxes_axis);
     CudaFreePinned(grid_dimensions);
-  } 
+  }
 
   if (allocated_num_objects != 0) {
     FreeAgentBuffers();
@@ -106,9 +106,10 @@ InitializeGPUData::~InitializeGPUData() {
 }
 
 // -----------------------------------------------------------------------------
-void InitializeGPUData::Initialize(uint64_t num_objects, uint64_t num_boxes,
-                const std::vector<AgentHandle::ElementIdx_t>& offs,
-                UniformGridEnvironment* g) {
+void InitializeGPUData::Initialize(
+    uint64_t num_objects, uint64_t num_boxes,
+    const std::vector<AgentHandle::ElementIdx_t>& offs,
+    UniformGridEnvironment* g) {
   if (current_timestamp == nullptr) {
     CudaAllocPinned(&current_timestamp, 1);
     CudaAllocPinned(&box_length, 1);
@@ -147,21 +148,21 @@ void InitializeGPUData::Initialize(uint64_t num_objects, uint64_t num_boxes,
 
 // -----------------------------------------------------------------------------
 void InitializeGPUData::FreeAgentBuffers() {
-    CudaFreePinned(cell_movements);
-    CudaFreePinned(cell_positions);
-    CudaFreePinned(cell_diameters);
-    CudaFreePinned(cell_adherence);
-    CudaFreePinned(cell_tractor_force);
-    CudaFreePinned(cell_boxid);
-    CudaFreePinned(mass);
-    CudaFreePinned(successors);
+  CudaFreePinned(cell_movements);
+  CudaFreePinned(cell_positions);
+  CudaFreePinned(cell_diameters);
+  CudaFreePinned(cell_adherence);
+  CudaFreePinned(cell_tractor_force);
+  CudaFreePinned(cell_boxid);
+  CudaFreePinned(mass);
+  CudaFreePinned(successors);
 }
 
 // -----------------------------------------------------------------------------
 void InitializeGPUData::FreeGridBuffers() {
-    CudaFreePinned(starts);
-    CudaFreePinned(lengths);
-    CudaFreePinned(timestamps);
+  CudaFreePinned(starts);
+  CudaFreePinned(lengths);
+  CudaFreePinned(timestamps);
 }
 
 // -----------------------------------------------------------------------------
@@ -213,8 +214,8 @@ struct UpdateCPUResults : public Functor<void, Agent*, AgentHandle> {
 };
 
 // -----------------------------------------------------------------------------
-UpdateCPUResults::UpdateCPUResults(double* cm,
-                 const std::vector<AgentHandle::ElementIdx_t>& offs) {
+UpdateCPUResults::UpdateCPUResults(
+    double* cm, const std::vector<AgentHandle::ElementIdx_t>& offs) {
   cell_movements = cm;
   offset = offs;
 }
@@ -339,8 +340,7 @@ void MechanicalForcesOpCuda::TearDown() {
   cdo_->Synch();
   Timing timer("MechanicalForcesOpCuda::TearDown");
   auto u = UpdateCPUResults(i_->cell_movements, i_->offset);
-  Simulation::GetActive()->GetResourceManager()->ForEachAgentParallel(1000,
-                                                                      u);
+  Simulation::GetActive()->GetResourceManager()->ForEachAgentParallel(1000, u);
 }
 
 }  // namespace bdm

--- a/src/core/operation/mechanical_forces_op_cuda.cc
+++ b/src/core/operation/mechanical_forces_op_cuda.cc
@@ -239,7 +239,7 @@ void UpdateCPUResults::operator()(Agent* agent, AgentHandle ah) {
 
 // -----------------------------------------------------------------------------
 void MechanicalForcesOpCuda::SetUp() {
-  Timing timer("MechanicalForcesOpCuda::SetUp");
+  // Timing timer("MechanicalForcesOpCuda::SetUp");
   auto* sim = Simulation::GetActive();
   auto* grid = dynamic_cast<UniformGridEnvironment*>(sim->GetEnvironment());
   auto* rm = sim->GetResourceManager();
@@ -265,7 +265,7 @@ void MechanicalForcesOpCuda::SetUp() {
   }
   i_->Initialize(total_num_objects, num_boxes, offset, grid);
   {
-    Timing timer("MechanicalForcesOpCuda::toColumnar");
+    // Timing timer("MechanicalForcesOpCuda::toColumnar");
     rm->ForEachAgentParallel(1000, *i_);
   }
 
@@ -325,7 +325,7 @@ void MechanicalForcesOpCuda::operator()() {
   double squared_radius =
       grid->GetLargestObjectSize() * grid->GetLargestObjectSize();
 
-  Timing timer("MechanicalForcesOpCuda::Kernel");
+  // Timing timer("MechanicalForcesOpCuda::Kernel");
   cdo_->LaunchMechanicalForcesKernel(
       i_->cell_positions, i_->cell_diameters, i_->cell_tractor_force,
       i_->cell_adherence, i_->cell_boxid, i_->mass,
@@ -338,7 +338,7 @@ void MechanicalForcesOpCuda::operator()() {
 // -----------------------------------------------------------------------------
 void MechanicalForcesOpCuda::TearDown() {
   cdo_->Synch();
-  Timing timer("MechanicalForcesOpCuda::TearDown");
+  // Timing timer("MechanicalForcesOpCuda::TearDown");
   auto u = UpdateCPUResults(i_->cell_movements, i_->offset);
   Simulation::GetActive()->GetResourceManager()->ForEachAgentParallel(1000, u);
 }

--- a/src/core/operation/mechanical_forces_op_cuda.cc
+++ b/src/core/operation/mechanical_forces_op_cuda.cc
@@ -1,0 +1,346 @@
+// -----------------------------------------------------------------------------
+//
+// Copyright (C) The BioDynaMo Project.
+// All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// See the LICENSE file distributed with this work for details.
+// See the NOTICE file distributed with this work for additional information
+// regarding copyright ownership.
+//
+// -----------------------------------------------------------------------------
+
+#include "core/operation/mechanical_forces_op_cuda.h"
+#include <vector>
+
+#include "core/agent/agent_handle.h"
+#include "core/agent/cell.h"
+#include "core/environment/environment.h"
+#include "core/environment/uniform_grid_environment.h"
+#include "core/gpu/cuda_pinned_memory.h"
+#include "core/operation/bound_space_op.h"
+#include "core/resource_manager.h"
+#include "core/shape.h"
+#include "core/simulation.h"
+#include "core/util/log.h"
+#include "core/util/thread_info.h"
+#include "core/util/timing.h"
+#include "core/util/type.h"
+#include "core/util/vtune_helper.h"
+
+namespace bdm {
+
+// -----------------------------------------------------------------------------
+void IsNonSphericalObjectPresent(const Agent* agent, bool* answer) {
+  if (agent->GetShape() != Shape::kSphere) {
+    *answer = true;
+  }
+}
+
+namespace detail {
+  
+// -----------------------------------------------------------------------------
+struct InitializeGPUData : public Functor<void, Agent*, AgentHandle> {
+  bool is_non_spherical_object = false;
+  
+  double* cell_movements = nullptr;
+  double* cell_positions = nullptr;
+  double* cell_diameters = nullptr;
+  double* cell_adherence = nullptr;
+  double* cell_tractor_force = nullptr;
+  uint32_t* cell_boxid = nullptr;
+  double* mass = nullptr;
+  uint32_t* successors = nullptr;
+
+  std::vector<AgentHandle::ElementIdx_t> offset;
+
+  uint32_t* starts = nullptr;
+  uint16_t* lengths = nullptr;
+  uint64_t* timestamps = nullptr;
+  uint64_t* current_timestamp = nullptr;
+  uint32_t* box_length = nullptr;
+  uint32_t* num_boxes_axis = nullptr;
+  int32_t* grid_dimensions = nullptr;
+  UniformGridEnvironment* grid = nullptr;
+
+  uint64_t allocated_num_objects = 0;
+  uint64_t allocated_num_boxes = 0;
+
+  InitializeGPUData();
+
+  virtual ~InitializeGPUData();
+  
+  void Initialize(uint64_t num_objects, uint64_t num_boxes,
+                  const std::vector<AgentHandle::ElementIdx_t>& offs,
+                  UniformGridEnvironment* g);
+
+  void operator()(Agent* agent, AgentHandle ah) override;
+
+  private:
+  void FreeAgentBuffers();
+
+  void FreeGridBuffers();
+};
+    
+// -----------------------------------------------------------------------------
+InitializeGPUData::InitializeGPUData() {}
+
+// -----------------------------------------------------------------------------
+InitializeGPUData::~InitializeGPUData() {
+  if (current_timestamp != nullptr) {
+    CudaFreePinned(current_timestamp);
+    CudaFreePinned(box_length);
+    CudaFreePinned(num_boxes_axis);
+    CudaFreePinned(grid_dimensions);
+  } 
+
+  if (allocated_num_objects != 0) {
+    FreeAgentBuffers();
+  }
+
+  if (allocated_num_boxes != 0) {
+    FreeGridBuffers();
+  }
+}
+
+// -----------------------------------------------------------------------------
+void InitializeGPUData::Initialize(uint64_t num_objects, uint64_t num_boxes,
+                const std::vector<AgentHandle::ElementIdx_t>& offs,
+                UniformGridEnvironment* g) {
+  if (current_timestamp == nullptr) {
+    CudaAllocPinned(&current_timestamp, 1);
+    CudaAllocPinned(&box_length, 1);
+    CudaAllocPinned(&num_boxes_axis, 3);
+    CudaAllocPinned(&grid_dimensions, 3);
+  }
+
+  if (allocated_num_objects < num_objects) {
+    if (allocated_num_objects != 0) {
+      FreeAgentBuffers();
+    }
+    allocated_num_objects = num_objects * 1.25;
+    CudaAllocPinned(&cell_movements, allocated_num_objects * 3);
+    CudaAllocPinned(&cell_positions, allocated_num_objects * 3);
+    CudaAllocPinned(&cell_diameters, allocated_num_objects);
+    CudaAllocPinned(&cell_adherence, allocated_num_objects);
+    CudaAllocPinned(&cell_tractor_force, allocated_num_objects * 3);
+    CudaAllocPinned(&cell_boxid, allocated_num_objects);
+    CudaAllocPinned(&mass, allocated_num_objects);
+    CudaAllocPinned(&successors, allocated_num_objects);
+  }
+
+  if (allocated_num_boxes < num_boxes) {
+    if (allocated_num_boxes != 0) {
+      FreeGridBuffers();
+    }
+    allocated_num_boxes = num_boxes * 1.25;
+    CudaAllocPinned(&starts, allocated_num_boxes);
+    CudaAllocPinned(&lengths, allocated_num_boxes);
+    CudaAllocPinned(&timestamps, allocated_num_boxes);
+  }
+
+  offset = offs;
+  grid = g;
+}
+
+// -----------------------------------------------------------------------------
+void InitializeGPUData::FreeAgentBuffers() {
+    CudaFreePinned(cell_movements);
+    CudaFreePinned(cell_positions);
+    CudaFreePinned(cell_diameters);
+    CudaFreePinned(cell_adherence);
+    CudaFreePinned(cell_tractor_force);
+    CudaFreePinned(cell_boxid);
+    CudaFreePinned(mass);
+    CudaFreePinned(successors);
+}
+
+// -----------------------------------------------------------------------------
+void InitializeGPUData::FreeGridBuffers() {
+    CudaFreePinned(starts);
+    CudaFreePinned(lengths);
+    CudaFreePinned(timestamps);
+}
+
+// -----------------------------------------------------------------------------
+void InitializeGPUData::operator()(Agent* agent, AgentHandle ah) {
+  // Check if there are any non-spherical objects in our simulation, because
+  // GPU accelerations currently supports only sphere-sphere interactions
+  IsNonSphericalObjectPresent(agent, &is_non_spherical_object);
+  if (is_non_spherical_object) {
+    Log::Fatal("MechanicalForcesOpCuda",
+               "\nWe detected a non-spherical object during the GPU "
+               "execution. This is currently not supported.");
+    return;
+  }
+  auto* cell = bdm_static_cast<Cell*>(agent);
+  auto idx = offset[ah.GetNumaNode()] + ah.GetElementIdx();
+  auto idxt3 = idx * 3;
+  mass[idx] = cell->GetMass();
+  cell_diameters[idx] = cell->GetDiameter();
+  cell_adherence[idx] = cell->GetAdherence();
+  const auto& tf = cell->GetTractorForce();
+  const auto& pos = cell->GetPosition();
+
+  for (uint64_t i = 0; i < 3; ++i) {
+    cell_tractor_force[idxt3 + i] = tf[i];
+    cell_positions[idxt3 + i] = pos[i];
+  }
+
+  cell_boxid[idx] = cell->GetBoxIdx();
+
+  // populate successor list
+  auto nid = ah.GetNumaNode();
+  auto el = ah.GetElementIdx();
+  successors[idx] = offset[grid->successors_.data_[nid][el].GetNumaNode()] +
+                    grid->successors_.data_[nid][el].GetElementIdx();
+}
+
+}  // namespace detail
+
+// -----------------------------------------------------------------------------
+struct UpdateCPUResults : public Functor<void, Agent*, AgentHandle> {
+  double* cell_movements = nullptr;
+  std::vector<AgentHandle::ElementIdx_t> offset;
+
+  UpdateCPUResults(double* cm,
+                   const std::vector<AgentHandle::ElementIdx_t>& offs);
+  virtual ~UpdateCPUResults();
+
+  void operator()(Agent* agent, AgentHandle ah) override;
+};
+
+// -----------------------------------------------------------------------------
+UpdateCPUResults::UpdateCPUResults(double* cm,
+                 const std::vector<AgentHandle::ElementIdx_t>& offs) {
+  cell_movements = cm;
+  offset = offs;
+}
+
+// -----------------------------------------------------------------------------
+UpdateCPUResults::~UpdateCPUResults() {}
+
+// -----------------------------------------------------------------------------
+void UpdateCPUResults::operator()(Agent* agent, AgentHandle ah) {
+  auto* param = Simulation::GetActive()->GetParam();
+  auto* cell = bdm_static_cast<Cell*>(agent);
+  auto idx = offset[ah.GetNumaNode()] + ah.GetElementIdx();
+  idx *= 3;
+  Double3 new_pos = {cell_movements[idx], cell_movements[idx + 1],
+                     cell_movements[idx + 2]};
+  cell->UpdatePosition(new_pos);
+  if (param->bound_space) {
+    ApplyBoundingBox(agent, param->min_bound, param->max_bound);
+  }
+}
+
+// -----------------------------------------------------------------------------
+void MechanicalForcesOpCuda::SetUp() {
+  Timing timer("MechanicalForcesOpCuda::SetUp");
+  auto* sim = Simulation::GetActive();
+  auto* grid = dynamic_cast<UniformGridEnvironment*>(sim->GetEnvironment());
+  auto* rm = sim->GetResourceManager();
+
+  if (!grid) {
+    Log::Fatal(
+        "MechanicalForcesOpCuda::operator()",
+        "MechanicalForcesOpCuda only works with UniformGridEnvironement.");
+  }
+
+  auto num_numa_nodes = ThreadInfo::GetInstance()->GetNumaNodes();
+  std::vector<AgentHandle::ElementIdx_t> offset(num_numa_nodes);
+  offset[0] = 0;
+  for (int nn = 1; nn < num_numa_nodes; nn++) {
+    offset[nn] = offset[nn - 1] + rm->GetNumAgents(nn - 1);
+  }
+
+  auto total_num_objects = rm->GetNumAgents();
+  auto num_boxes = grid->boxes_.size();
+
+  if (i_ == nullptr) {
+    i_ = new detail::InitializeGPUData();
+  }
+  i_->Initialize(total_num_objects, num_boxes, offset, grid);
+  {
+    Timing timer("MechanicalForcesOpCuda::toColumnar");
+    rm->ForEachAgentParallel(1000, *i_);
+  }
+
+  *i_->current_timestamp = grid->timestamp_;
+#pragma omp parallel for
+  for (uint64_t i = 0; i < grid->boxes_.size(); ++i) {
+    auto& box = grid->boxes_[i];
+    i_->timestamps[i] = box.timestamp_;
+    if (box.timestamp_ == *i_->current_timestamp) {
+      i_->lengths[i] = box.length_;
+      i_->starts[i] =
+          offset[box.start_.GetNumaNode()] + box.start_.GetElementIdx();
+    }
+  }
+  grid->GetGridInfo(i_->box_length, i_->num_boxes_axis, i_->grid_dimensions);
+}
+
+// -----------------------------------------------------------------------------
+void MechanicalForcesOpCuda::operator()() {
+  auto* sim = Simulation::GetActive();
+  auto* grid = dynamic_cast<UniformGridEnvironment*>(sim->GetEnvironment());
+  auto* param = sim->GetParam();
+  auto* rm = sim->GetResourceManager();
+
+  uint32_t total_num_objects = rm->GetNumAgents();
+  auto num_boxes = grid->boxes_.size();
+  // If this is the first time we perform physics on GPU using CUDA
+  if (cdo_ == nullptr) {
+    // Allocate 25% more memory so we don't need to reallocate GPU memory
+    // for every (small) change
+    total_num_objects_ = static_cast<uint32_t>(1.25 * total_num_objects);
+    num_boxes_ = static_cast<uint32_t>(1.25 * num_boxes);
+
+    // Allocate required GPU memory
+    cdo_ = new MechanicalForcesOpCudaKernel(total_num_objects_, num_boxes_);
+  } else {
+    // If the number of agents increased
+    if (total_num_objects >= total_num_objects_) {
+      Log::Info("MechanicalForcesOpCuda",
+                "\nThe number of cells increased signficantly (from ",
+                total_num_objects_, " to ", total_num_objects,
+                "), agent we allocate bigger GPU buffers\n");
+      total_num_objects_ = static_cast<uint32_t>(1.25 * total_num_objects);
+      cdo_->ResizeCellBuffers(total_num_objects_);
+    }
+
+    // If the neighbor grid size increased
+    if (num_boxes >= num_boxes_) {
+      Log::Info("MechanicalForcesOpCuda",
+                "\nThe number of boxes increased signficantly (from ",
+                num_boxes_, " to ", "), so we allocate bigger GPU buffers\n");
+      num_boxes_ = static_cast<uint32_t>(1.25 * num_boxes);
+      cdo_->ResizeGridBuffers(num_boxes_);
+    }
+  }
+
+  double squared_radius =
+      grid->GetLargestObjectSize() * grid->GetLargestObjectSize();
+
+  Timing timer("MechanicalForcesOpCuda::Kernel");
+  cdo_->LaunchMechanicalForcesKernel(
+      i_->cell_positions, i_->cell_diameters, i_->cell_tractor_force,
+      i_->cell_adherence, i_->cell_boxid, i_->mass,
+      &(param->simulation_time_step), &(param->simulation_max_displacement),
+      &squared_radius, &total_num_objects, i_->starts, i_->lengths,
+      i_->timestamps, i_->current_timestamp, i_->successors, i_->box_length,
+      i_->num_boxes_axis, i_->grid_dimensions, i_->cell_movements);
+}
+
+// -----------------------------------------------------------------------------
+void MechanicalForcesOpCuda::TearDown() {
+  cdo_->Synch();
+  Timing timer("MechanicalForcesOpCuda::TearDown");
+  auto u = UpdateCPUResults(i_->cell_movements, i_->offset);
+  Simulation::GetActive()->GetResourceManager()->ForEachAgentParallel(1000,
+                                                                      u);
+}
+
+}  // namespace bdm

--- a/src/core/operation/mechanical_forces_op_cuda.h
+++ b/src/core/operation/mechanical_forces_op_cuda.h
@@ -17,320 +17,34 @@
 #ifndef CORE_OPERATION_MECHANICAL_FORCES_OP_CUDA_H_
 #define CORE_OPERATION_MECHANICAL_FORCES_OP_CUDA_H_
 
-#include <vector>
-
-#include "core/agent/agent_handle.h"
-#include "core/agent/cell.h"
-#include "core/environment/environment.h"
-#include "core/environment/uniform_grid_environment.h"
-#include "core/gpu/mechanical_forces_op_cuda_kernel.h"
-#include "core/gpu/cuda_pinned_memory.h"
-#include "core/operation/bound_space_op.h"
+#include "core/operation/operation.h"
 #include "core/operation/operation_registry.h"
-#include "core/resource_manager.h"
-#include "core/shape.h"
-#include "core/simulation.h"
-#include "core/util/log.h"
-#include "core/util/thread_info.h"
-#include "core/util/timing.h"
-#include "core/util/type.h"
-#include "core/util/vtune_helper.h"
+#include "core/gpu/mechanical_forces_op_cuda_kernel.h"
 
 namespace bdm {
 
-inline void IsNonSphericalObjectPresent(const Agent* agent, bool* answer) {
-  if (agent->GetShape() != Shape::kSphere) {
-    *answer = true;
-  }
-}
+namespace detail {
+
+struct InitializeGPUData;
+
+}  // namespace detail
 
 /// Defines the 3D physical interactions between physical objects
 struct MechanicalForcesOpCuda : public StandaloneOperationImpl {
   BDM_OP_HEADER(MechanicalForcesOpCuda);
 
- private:
-  struct InitializeGPUData;
-  struct UpdateCPUResults;
-
  public:
-  void SetUp() override {
-    Timing timer("MechanicalForcesOpCuda::SetUp");
-    auto* sim = Simulation::GetActive();
-    auto* grid = dynamic_cast<UniformGridEnvironment*>(sim->GetEnvironment());
-    auto* rm = sim->GetResourceManager();
+  void SetUp() override;
 
-    if (!grid) {
-      Log::Fatal(
-          "MechanicalForcesOpCuda::operator()",
-          "MechanicalForcesOpCuda only works with UniformGridEnvironement.");
-    }
+  void operator()() override;
 
-    auto num_numa_nodes = ThreadInfo::GetInstance()->GetNumaNodes();
-    std::vector<AgentHandle::ElementIdx_t> offset(num_numa_nodes);
-    offset[0] = 0;
-    for (int nn = 1; nn < num_numa_nodes; nn++) {
-      offset[nn] = offset[nn - 1] + rm->GetNumAgents(nn - 1);
-    }
-
-    auto total_num_objects = rm->GetNumAgents();
-    auto num_boxes = grid->boxes_.size();
-
-    i_->Initialize(total_num_objects, num_boxes, offset, grid);
-    {
-      Timing timer("MechanicalForcesOpCuda::toColumnar");
-      rm->ForEachAgentParallel(1000, *i_);
-    }
-    // Populate successor list
-    // for (int i = 0; i < num_numa_nodes; i++) {
-    //   for (size_t j = 0; j < rm->GetNumAgents(i); j++) {
-    //     auto idx = offset[i] + j;
-    //     i_->successors[idx] =
-    //         offset[grid->successors_.data_[i][j].GetNumaNode()] +
-    //         grid->successors_.data_[i][j].GetElementIdx();
-    //   }
-    // }
-
-    *i_->current_timestamp = grid->timestamp_;
-#pragma omp parallel for
-    for (uint64_t i = 0; i < grid->boxes_.size(); ++i) {
-      // for (auto& box : grid->boxes_) {
-      auto& box = grid->boxes_[i];
-      i_->timestamps[i] = box.timestamp_;
-      if (box.timestamp_ == *i_->current_timestamp) {
-        i_->lengths[i] = box.length_;
-        i_->starts[i] =
-            offset[box.start_.GetNumaNode()] + box.start_.GetElementIdx();
-      }
-    }
-    grid->GetGridInfo(i_->box_length, i_->num_boxes_axis, i_->grid_dimensions);
-  }
-
-  void operator()() override {
-    auto* sim = Simulation::GetActive();
-    auto* grid = dynamic_cast<UniformGridEnvironment*>(sim->GetEnvironment());
-    auto* param = sim->GetParam();
-    auto* rm = sim->GetResourceManager();
-
-    uint32_t total_num_objects = rm->GetNumAgents();
-    auto num_boxes = grid->boxes_.size();
-    // If this is the first time we perform physics on GPU using CUDA
-    if (cdo_ == nullptr) {
-      // Allocate 25% more memory so we don't need to reallocate GPU memory
-      // for every (small) change
-      total_num_objects_ = static_cast<uint32_t>(1.25 * total_num_objects);
-      num_boxes_ = static_cast<uint32_t>(1.25 * num_boxes);
-
-      // Allocate required GPU memory
-      cdo_ = new MechanicalForcesOpCudaKernel(total_num_objects_, num_boxes_);
-    } else {
-      // If the number of agents increased
-      if (total_num_objects >= total_num_objects_) {
-        Log::Info("MechanicalForcesOpCuda",
-                  "\nThe number of cells increased signficantly (from ",
-                  total_num_objects_, " to ", total_num_objects,
-                  "), agent we allocate bigger GPU buffers\n");
-        total_num_objects_ = static_cast<uint32_t>(1.25 * total_num_objects);
-        cdo_->ResizeCellBuffers(total_num_objects_);
-      }
-
-      // If the neighbor grid size increased
-      if (num_boxes >= num_boxes_) {
-        Log::Info("MechanicalForcesOpCuda",
-                  "\nThe number of boxes increased signficantly (from ",
-                  num_boxes_, " to ", "), so we allocate bigger GPU buffers\n");
-        num_boxes_ = static_cast<uint32_t>(1.25 * num_boxes);
-        cdo_->ResizeGridBuffers(num_boxes_);
-      }
-    }
-
-    double squared_radius =
-        grid->GetLargestObjectSize() * grid->GetLargestObjectSize();
-
-    Timing timer("MechanicalForcesOpCuda::Kernel");
-    cdo_->LaunchMechanicalForcesKernel(
-        i_->cell_positions, i_->cell_diameters, i_->cell_tractor_force,
-        i_->cell_adherence, i_->cell_boxid, i_->mass,
-        &(param->simulation_time_step), &(param->simulation_max_displacement),
-        &squared_radius, &total_num_objects, i_->starts, i_->lengths,
-        i_->timestamps, i_->current_timestamp, i_->successors, i_->box_length,
-        i_->num_boxes_axis, i_->grid_dimensions, i_->cell_movements);
-  }
-
-  void TearDown() override {
-    cdo_->Synch();
-    Timing timer("MechanicalForcesOpCuda::TearDown");
-    auto u = UpdateCPUResults(i_->cell_movements, i_->offset);
-    Simulation::GetActive()->GetResourceManager()->ForEachAgentParallel(1000,
-                                                                        u);
-  }
+  void TearDown() override;
 
  private:
   MechanicalForcesOpCudaKernel* cdo_ = nullptr;
-  InitializeGPUData* i_ = new InitializeGPUData();
+  detail::InitializeGPUData* i_ = nullptr;
   uint32_t num_boxes_ = 0;
   uint32_t total_num_objects_ = 0;
-
-  struct UpdateCPUResults : public Functor<void, Agent*, AgentHandle> {
-    double* cell_movements = nullptr;
-    std::vector<AgentHandle::ElementIdx_t> offset;
-
-    UpdateCPUResults(double* cm,
-                     const std::vector<AgentHandle::ElementIdx_t>& offs) {
-      cell_movements = cm;
-      offset = offs;
-    }
-
-    void operator()(Agent* agent, AgentHandle ah) override {
-      auto* param = Simulation::GetActive()->GetParam();
-      auto* cell = bdm_static_cast<Cell*>(agent);
-      auto idx = offset[ah.GetNumaNode()] + ah.GetElementIdx();
-      idx *= 3;
-      Double3 new_pos = {cell_movements[idx], cell_movements[idx + 1],
-                         cell_movements[idx + 2]};
-      cell->UpdatePosition(new_pos);
-      if (param->bound_space) {
-        ApplyBoundingBox(agent, param->min_bound, param->max_bound);
-      }
-    }
-  };
-
-  struct InitializeGPUData : public Functor<void, Agent*, AgentHandle> {
-    bool is_non_spherical_object = false;
-    // Cannot use Double3 here, because the `data()` function returns a const
-    // pointer to the underlying array, whereas the CUDA kernel will cast it to
-    // a void pointer. The conversion of `const double *` to `void *` is
-    // illegal.
-    double* cell_movements = nullptr;
-    double* cell_positions = nullptr;
-    double* cell_diameters = nullptr;
-    double* cell_adherence = nullptr;
-    double* cell_tractor_force = nullptr;
-    uint32_t* cell_boxid = nullptr;
-    double* mass = nullptr;
-    uint32_t* successors = nullptr;
-
-    std::vector<AgentHandle::ElementIdx_t> offset;
-
-    uint32_t* starts = nullptr;
-    uint16_t* lengths = nullptr;
-    uint64_t* timestamps = nullptr;
-    uint64_t* current_timestamp = nullptr;
-    uint32_t* box_length = nullptr;
-    uint32_t* num_boxes_axis = nullptr;
-    int32_t* grid_dimensions = nullptr;
-    UniformGridEnvironment* grid = nullptr;
-
-    uint64_t allocated_num_objects = 0;
-    uint64_t allocated_num_boxes = 0;
-
-    InitializeGPUData() {}
-
-    virtual ~InitializeGPUData() {
-      if (current_timestamp != nullptr) {
-        CudaFreePinned(current_timestamp);
-        CudaFreePinned(box_length);
-        CudaFreePinned(num_boxes_axis);
-        CudaFreePinned(grid_dimensions);
-      } 
-
-      if (allocated_num_objects != 0) {
-        FreeAgentBuffers();
-      }
-
-      if (allocated_num_boxes != 0) {
-        FreeGridBuffers();
-      }
-    }
-
-    void Initialize(uint64_t num_objects, uint64_t num_boxes,
-                    const std::vector<AgentHandle::ElementIdx_t>& offs,
-                    UniformGridEnvironment* g) {
-      if (current_timestamp == nullptr) {
-        CudaAllocPinned(&current_timestamp, 1);
-        CudaAllocPinned(&box_length, 1);
-        CudaAllocPinned(&num_boxes_axis, 3);
-        CudaAllocPinned(&grid_dimensions, 3);
-      }
-
-      if (allocated_num_objects < num_objects) {
-        if (allocated_num_objects != 0) {
-          FreeAgentBuffers();
-        }
-        allocated_num_objects = num_objects * 1.25;
-        CudaAllocPinned(&cell_movements, allocated_num_objects * 3);
-        CudaAllocPinned(&cell_positions, allocated_num_objects * 3);
-        CudaAllocPinned(&cell_diameters, allocated_num_objects);
-        CudaAllocPinned(&cell_adherence, allocated_num_objects);
-        CudaAllocPinned(&cell_tractor_force, allocated_num_objects * 3);
-        CudaAllocPinned(&cell_boxid, allocated_num_objects);
-        CudaAllocPinned(&mass, allocated_num_objects);
-        CudaAllocPinned(&successors, allocated_num_objects);
-      }
-
-      if (allocated_num_boxes < num_boxes) {
-        if (allocated_num_boxes != 0) {
-          FreeGridBuffers();
-        }
-        allocated_num_boxes = num_boxes * 1.25;
-        CudaAllocPinned(&starts, allocated_num_boxes);
-        CudaAllocPinned(&lengths, allocated_num_boxes);
-        CudaAllocPinned(&timestamps, allocated_num_boxes);
-      }
-
-      offset = offs;
-      grid = g;
-    }
-
-    void FreeAgentBuffers() {
-        CudaFreePinned(cell_movements);
-        CudaFreePinned(cell_positions);
-        CudaFreePinned(cell_diameters);
-        CudaFreePinned(cell_adherence);
-        CudaFreePinned(cell_tractor_force);
-        CudaFreePinned(cell_boxid);
-        CudaFreePinned(mass);
-        CudaFreePinned(successors);
-    }
-
-    void FreeGridBuffers() {
-        CudaFreePinned(starts);
-        CudaFreePinned(lengths);
-        CudaFreePinned(timestamps);
-    }
-
-    void operator()(Agent* agent, AgentHandle ah) override {
-      // Check if there are any non-spherical objects in our simulation, because
-      // GPU accelerations currently supports only sphere-sphere interactions
-      IsNonSphericalObjectPresent(agent, &is_non_spherical_object);
-      if (is_non_spherical_object) {
-        Log::Fatal("MechanicalForcesOpCuda",
-                   "\nWe detected a non-spherical object during the GPU "
-                   "execution. This is currently not supported.");
-        return;
-      }
-      auto* cell = bdm_static_cast<Cell*>(agent);
-      auto idx = offset[ah.GetNumaNode()] + ah.GetElementIdx();
-      auto idxt3 = idx * 3;
-      mass[idx] = cell->GetMass();
-      cell_diameters[idx] = cell->GetDiameter();
-      cell_adherence[idx] = cell->GetAdherence();
-      const auto& tf = cell->GetTractorForce();
-      const auto& pos = cell->GetPosition();
-
-      for (uint64_t i = 0; i < 3; ++i) {
-        cell_tractor_force[idxt3 + i] = tf[i];
-        cell_positions[idxt3 + i] = pos[i];
-      }
-
-      cell_boxid[idx] = cell->GetBoxIdx();
-
-      // populate successor list
-      auto nid = ah.GetNumaNode();
-      auto el = ah.GetElementIdx();
-      successors[idx] = offset[grid->successors_.data_[nid][el].GetNumaNode()] +
-                        grid->successors_.data_[nid][el].GetElementIdx();
-    }
-  };
 };
 
 }  // namespace bdm

--- a/src/core/operation/mechanical_forces_op_cuda.h
+++ b/src/core/operation/mechanical_forces_op_cuda.h
@@ -227,17 +227,16 @@ struct MechanicalForcesOpCuda : public StandaloneOperationImpl {
     uint64_t allocated_num_objects = 0;
     uint64_t allocated_num_boxes = 0;
 
-    InitializeGPUData() {
+    InitializeGPUData() {}
+
+    void Initialize(uint64_t num_objects, uint64_t num_boxes,
+                      const std::vector<AgentHandle::ElementIdx_t>& offs, 
+                      UniformGridEnvironment* g) {
       // FIXME memory leak
       AllocPinned(&current_timestamp, 1);
       AllocPinned(&box_length, 1);
       AllocPinned(&num_boxes_axis, 3);
       AllocPinned(&grid_dimensions, 3);
-    }
-
-    void Initialize(uint64_t num_objects, uint64_t num_boxes,
-                      const std::vector<AgentHandle::ElementIdx_t>& offs, 
-                      UniformGridEnvironment* g) {
       // FIXME huge memory leak
       if (allocated_num_objects < num_objects) {
         allocated_num_objects = num_objects;

--- a/src/core/operation/mechanical_forces_op_cuda.h
+++ b/src/core/operation/mechanical_forces_op_cuda.h
@@ -17,9 +17,9 @@
 #ifndef CORE_OPERATION_MECHANICAL_FORCES_OP_CUDA_H_
 #define CORE_OPERATION_MECHANICAL_FORCES_OP_CUDA_H_
 
+#include "core/gpu/mechanical_forces_op_cuda_kernel.h"
 #include "core/operation/operation.h"
 #include "core/operation/operation_registry.h"
-#include "core/gpu/mechanical_forces_op_cuda_kernel.h"
 
 namespace bdm {
 

--- a/src/core/scheduler.h
+++ b/src/core/scheduler.h
@@ -35,7 +35,7 @@ class SimulationBackup;
 class VisualizationAdaptor;
 class RootAdaptor;
 struct BoundSpace;
-struct MechanicalForcesOp;
+class MechanicalForcesOp;
 struct DiffusionOp;
 
 enum OpType { kSchedule, kPreSchedule, kPostSchedule };


### PR DESCRIPTION
* Only use async calls for data transfers and kernel invocations to free the CPUs for other tasks
* Use pinned (non-pageable) memory to avoid one data copy and enable async data transfers
* Optimize filling of columnar buffers
* Fix memory leak
* Add CudaTimer

These changes improved the runtime of the whole soma clustering benchmark by a factor of 2.