### PR TITLE
Update URL in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,4 @@
 # Contributing Guidelines
 
-You can find our contributing guidelines in our [developer guide](https://biodynamo.github.io/dev/contribute/)
+You can find our contributing guidelines in our
+[developer guide](https://biodynamo.org/docs/devguide/contribute/).


### PR DESCRIPTION
I updated the URL in the file CONTRIBUTING.md.
The previous URL was outdated and redirected the users to a "error 404" page.
This problem was fixed by simply replacing the URL.