### PR TITLE
Set environment

### DIFF
--- a/src/core/simulation.cc
+++ b/src/core/simulation.cc
@@ -355,6 +355,13 @@ void Simulation::InitializeMembers() {
   scheduler_ = new Scheduler();
 }
 
+void Simulation::SetEnvironement(Environment* env) {
+  if (environment_ != nullptr) {
+    delete environment_;
+  }
+  environment_ = env;
+}
+
 void Simulation::InitializeRuntimeParams(
     CommandLineOptions* clo, const std::function<void(Param*)>& set_param,
     const std::vector<std::string>& ctor_config_files) {

--- a/src/core/simulation.cc
+++ b/src/core/simulation.cc
@@ -355,7 +355,7 @@ void Simulation::InitializeMembers() {
   scheduler_ = new Scheduler();
 }
 
-void Simulation::SetEnvironement(Environment* env) {
+void Simulation::SetEnvironment(Environment* env) {
   if (environment_ != nullptr) {
     delete environment_;
   }

--- a/src/core/simulation.h
+++ b/src/core/simulation.h
@@ -102,7 +102,7 @@ class Simulation {
 
   /// Set a specific environment for the simulation. *env must point to an
   /// object instance of a subclass of Environment.
-  void SetEnvironement(Environment* env);
+  void SetEnvironment(Environment* env);
 
   Scheduler* GetScheduler();
 

--- a/src/core/simulation.h
+++ b/src/core/simulation.h
@@ -100,6 +100,10 @@ class Simulation {
 
   Environment* GetEnvironment();
 
+  /// Set a specific environment for the simulation. *env must point to an
+  /// object instance of a subclass of Environment.
+  void SetEnvironement(Environment* env);
+
   Scheduler* GetScheduler();
 
   void Simulate(uint64_t steps);

--- a/test/unit/core/container/shared_data_test.cc
+++ b/test/unit/core/container/shared_data_test.cc
@@ -1,3 +1,17 @@
+// -----------------------------------------------------------------------------
+//
+// Copyright (C) 2021 CERN & Newcastle University for the benefit of the
+// BioDynaMo collaboration. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// See the LICENSE file distributed with this work for details.
+// See the NOTICE file distributed with this work for additional information
+// regarding copyright ownership.
+//
+// -----------------------------------------------------------------------------
+
 #include "core/container/shared_data.h"
 #include <gtest/gtest.h>
 #include <vector>
@@ -44,7 +58,7 @@ TEST(SharedDataTest, CacheLineAlignment) {
           typename SharedData<double[BDM_CACHE_LINE_SIZE /
                                      sizeof(double)]>::Data::value_type>::value,
       BDM_CACHE_LINE_SIZE);
-  // Test size of vector components double[max_double], e.g. max cache line 
+  // Test size of vector components double[max_double], e.g. max cache line
   // capacity
   EXPECT_EQ(
       sizeof(typename SharedData<

--- a/test/unit/core/kd_tree_environment_test.cc
+++ b/test/unit/core/kd_tree_environment_test.cc
@@ -101,4 +101,13 @@ TEST(KDTreeTest, Setup) {
   EXPECT_EQ(expected_63, neighbors[AgentUid(63)]);
 }
 
+// Test if SetEnvironment method works correctly for KDTreeEnvironment.
+TEST(KDTreeTest, SetEnvironment) {
+  Simulation simulation(TEST_NAME);
+  auto* env = new KDTreeEnvironment();
+  EXPECT_NE(env, simulation.GetEnvironment());
+  simulation.SetEnvironment(env);
+  EXPECT_EQ(env, simulation.GetEnvironment());
+}
+
 }  // namespace bdm

--- a/test/unit/core/octree_environment_test.cc
+++ b/test/unit/core/octree_environment_test.cc
@@ -101,4 +101,13 @@ TEST(OctreeTest, Setup) {
   EXPECT_EQ(expected_63, neighbors[AgentUid(63)]);
 }
 
+// Test if SetEnvironment method works correctly for OctreeEnvironment.
+TEST(OctreeTest, SetEnvironment) {
+  Simulation simulation(TEST_NAME);
+  auto* env = new OctreeEnvironment();
+  EXPECT_NE(env, simulation.GetEnvironment());
+  simulation.SetEnvironment(env);
+  EXPECT_EQ(env, simulation.GetEnvironment());
+}
+
 }  // namespace bdm


### PR DESCRIPTION
Added `SetEnvironment` method to `simulate.h/.cc` such that users can include their custom environments into the simulation. The method is tested in the unit tests for the `OctreeEnvironment` and the `KDTreeEnvironment`.