### PR TITLE
Add class LambdaFunctor and function L2F to simplify functor creation

### DIFF
--- a/cmake/selection.xml
+++ b/cmake/selection.xml
@@ -19,6 +19,7 @@
     <class name="__gnu_cxx::__normal_iterator<double*,vector<double> >"/>
     <class name="__gnu_cxx::__normal_iterator<const double*,vector<double> >"/>
     <class name="std::function<void(bdm::Agent*)>"/>
+    <class pattern="bdm::LambdaFunctor*"/>
     <!-- list of classes with dictionary in libbiodynamo
          -> all selected classes from libbiodynamo-selection.xml -->
     <class name="bdm::neuroscience::NeuronSoma" />

--- a/demo/epidemiology/src/behavior.h
+++ b/demo/epidemiology/src/behavior.h
@@ -32,7 +32,7 @@ struct Infection : public Behavior {
         random->Uniform(0, 1) <= sparam->infection_probablity) {
       auto* ctxt = sim->GetExecutionContext();
       auto check_surrounding =
-          MakeFunctor([&](Agent* neighbor, double squared_distance) {
+          L2F([&](Agent* neighbor, double squared_distance) {
             auto* other = bdm_static_cast<const Person*>(neighbor);
             if (other->state_ == State::kInfected) {
               person->state_ = State::kInfected;

--- a/src/core/agent/agent.cc
+++ b/src/core/agent/agent.cc
@@ -86,13 +86,12 @@ void Agent::PropagateStaticness() {
   propagate_staticness_neighborhood_ = false;
   is_static_next_ts_ = false;
   auto* ctxt = Simulation::GetActive()->GetExecutionContext();
-  auto set_staticness =
-      MakeFunctor([this](Agent* neighbor, double squared_distance) {
-        double distance = this->GetDiameter() + neighbor->GetDiameter();
-        if (squared_distance < distance * distance) {
-          neighbor->SetStaticnessNextTimestep(false);
-        }
-      });
+  auto set_staticness = L2F([this](Agent* neighbor, double squared_distance) {
+    double distance = this->GetDiameter() + neighbor->GetDiameter();
+    if (squared_distance < distance * distance) {
+      neighbor->SetStaticnessNextTimestep(false);
+    }
+  });
   ctxt->ForEachNeighbor(set_staticness, *this);
 }
 

--- a/src/core/agent/agent.cc
+++ b/src/core/agent/agent.cc
@@ -74,18 +74,6 @@ void Agent::Update(const NewAgentEvent& event) {
   UpdateBehaviors(event);
 }
 
-struct SetStaticnessForEachNeighbor : public Functor<void, Agent*, double> {
-  Agent* agent_;
-  explicit SetStaticnessForEachNeighbor(Agent* agent) : agent_(agent) {}
-
-  void operator()(Agent* neighbor, double squared_distance) override {
-    double distance = agent_->GetDiameter() + neighbor->GetDiameter();
-    if (squared_distance < distance * distance) {
-      neighbor->SetStaticnessNextTimestep(false);
-    }
-  }
-};
-
 void Agent::PropagateStaticness() {
   if (!Simulation::GetActive()->GetParam()->detect_static_agents) {
     is_static_next_ts_ = false;
@@ -98,8 +86,13 @@ void Agent::PropagateStaticness() {
   propagate_staticness_neighborhood_ = false;
   is_static_next_ts_ = false;
   auto* ctxt = Simulation::GetActive()->GetExecutionContext();
-  SetStaticnessForEachNeighbor for_each(this);
-  ctxt->ForEachNeighbor(for_each, *this);
+  auto set_staticness = MakeFunctor([this](Agent* neighbor, double squared_distance) {
+    double distance = this->GetDiameter() + neighbor->GetDiameter();
+    if (squared_distance < distance * distance) {
+      neighbor->SetStaticnessNextTimestep(false);
+    }
+  });
+  ctxt->ForEachNeighbor(set_staticness, *this);
 }
 
 void Agent::RunDiscretization() {}

--- a/src/core/agent/agent.cc
+++ b/src/core/agent/agent.cc
@@ -86,12 +86,13 @@ void Agent::PropagateStaticness() {
   propagate_staticness_neighborhood_ = false;
   is_static_next_ts_ = false;
   auto* ctxt = Simulation::GetActive()->GetExecutionContext();
-  auto set_staticness = MakeFunctor([this](Agent* neighbor, double squared_distance) {
-    double distance = this->GetDiameter() + neighbor->GetDiameter();
-    if (squared_distance < distance * distance) {
-      neighbor->SetStaticnessNextTimestep(false);
-    }
-  });
+  auto set_staticness =
+      MakeFunctor([this](Agent* neighbor, double squared_distance) {
+        double distance = this->GetDiameter() + neighbor->GetDiameter();
+        if (squared_distance < distance * distance) {
+          neighbor->SetStaticnessNextTimestep(false);
+        }
+      });
   ctxt->ForEachNeighbor(set_staticness, *this);
 }
 

--- a/src/core/agent/cell.h
+++ b/src/core/agent/cell.h
@@ -248,22 +248,6 @@ class Cell : public Agent {
     SetPropagateStaticness();
   }
 
-  struct MechanicalForcesFunctor : Functor<void, Agent*, double> {
-    const InteractionForce* force;
-    Agent* agent;
-    Double3 translation_force_on_point_mass{0, 0, 0};
-
-    MechanicalForcesFunctor(const InteractionForce* force, Agent* agent)
-        : force(force), agent(agent) {}
-
-    void operator()(Agent* neighbor, double squared_distance) override {
-      auto neighbor_force = force->Calculate(agent, neighbor);
-      translation_force_on_point_mass[0] += neighbor_force[0];
-      translation_force_on_point_mass[1] += neighbor_force[1];
-      translation_force_on_point_mass[2] += neighbor_force[2];
-    }
-  };
-
   Double3 CalculateDisplacement(const InteractionForce* force,
                                 double squared_radius, double dt) override {
     // Basically, the idea is to make the sum of all the forces acting
@@ -293,10 +277,11 @@ class Cell : public Agent {
 
     // PHYSICS
     // the physics force to move the point mass
+    Double3 translation_force_on_point_mass{0, 0, 0};
 
     // the physics force to rotate the cell
     // Double3 rotation_force { 0, 0, 0 };
-
+    
     // 1) "artificial force" to maintain the sphere in the ecm simulation
     // boundaries--------
     // 2) Spring force from my neurites (translation and
@@ -306,15 +291,20 @@ class Cell : public Agent {
     //  (We check for every neighbor object if they touch us, i.e. push us
     //  away)
 
-    MechanicalForcesFunctor calculate_neighbor_forces(force, this);
     auto* ctxt = Simulation::GetActive()->GetExecutionContext();
+    auto calculate_neighbor_forces = MakeFunctor([&](Agent* neighbor, double squared_distance) {
+      auto neighbor_force = force->Calculate(this, neighbor);
+      translation_force_on_point_mass[0] += neighbor_force[0];
+      translation_force_on_point_mass[1] += neighbor_force[1];
+      translation_force_on_point_mass[2] += neighbor_force[2];
+    });
     ctxt->ForEachNeighbor(calculate_neighbor_forces, *this, squared_radius);
 
     // 4) PhysicalBonds
     // How the physics influences the next displacement
     double norm_of_force =
-        std::sqrt(calculate_neighbor_forces.translation_force_on_point_mass *
-                  calculate_neighbor_forces.translation_force_on_point_mass);
+        std::sqrt(translation_force_on_point_mass *
+                  translation_force_on_point_mass);
 
     // is there enough force to :
     //  - make us biologically move (Tractor) :
@@ -327,7 +317,7 @@ class Cell : public Agent {
     if (physical_translation) {
       // We scale the move with mass and time step
       movement_at_next_step +=
-          calculate_neighbor_forces.translation_force_on_point_mass * mh;
+          translation_force_on_point_mass * mh;
 
       // Performing the translation itself :
       // but we want to avoid huge jumps in the simulation, so there are

--- a/src/core/agent/cell.h
+++ b/src/core/agent/cell.h
@@ -293,7 +293,7 @@ class Cell : public Agent {
 
     auto* ctxt = Simulation::GetActive()->GetExecutionContext();
     auto calculate_neighbor_forces =
-        MakeFunctor([&](Agent* neighbor, double squared_distance) {
+        L2F([&](Agent* neighbor, double squared_distance) {
           auto neighbor_force = force->Calculate(this, neighbor);
           translation_force_on_point_mass[0] += neighbor_force[0];
           translation_force_on_point_mass[1] += neighbor_force[1];

--- a/src/core/agent/cell.h
+++ b/src/core/agent/cell.h
@@ -281,7 +281,7 @@ class Cell : public Agent {
 
     // the physics force to rotate the cell
     // Double3 rotation_force { 0, 0, 0 };
-    
+
     // 1) "artificial force" to maintain the sphere in the ecm simulation
     // boundaries--------
     // 2) Spring force from my neurites (translation and
@@ -292,19 +292,19 @@ class Cell : public Agent {
     //  away)
 
     auto* ctxt = Simulation::GetActive()->GetExecutionContext();
-    auto calculate_neighbor_forces = MakeFunctor([&](Agent* neighbor, double squared_distance) {
-      auto neighbor_force = force->Calculate(this, neighbor);
-      translation_force_on_point_mass[0] += neighbor_force[0];
-      translation_force_on_point_mass[1] += neighbor_force[1];
-      translation_force_on_point_mass[2] += neighbor_force[2];
-    });
+    auto calculate_neighbor_forces =
+        MakeFunctor([&](Agent* neighbor, double squared_distance) {
+          auto neighbor_force = force->Calculate(this, neighbor);
+          translation_force_on_point_mass[0] += neighbor_force[0];
+          translation_force_on_point_mass[1] += neighbor_force[1];
+          translation_force_on_point_mass[2] += neighbor_force[2];
+        });
     ctxt->ForEachNeighbor(calculate_neighbor_forces, *this, squared_radius);
 
     // 4) PhysicalBonds
     // How the physics influences the next displacement
-    double norm_of_force =
-        std::sqrt(translation_force_on_point_mass *
-                  translation_force_on_point_mass);
+    double norm_of_force = std::sqrt(translation_force_on_point_mass *
+                                     translation_force_on_point_mass);
 
     // is there enough force to :
     //  - make us biologically move (Tractor) :
@@ -316,8 +316,7 @@ class Cell : public Agent {
     // adding the physics translation (scale by weight) if important enough
     if (physical_translation) {
       // We scale the move with mass and time step
-      movement_at_next_step +=
-          translation_force_on_point_mass * mh;
+      movement_at_next_step += translation_force_on_point_mass * mh;
 
       // Performing the translation itself :
       // but we want to avoid huge jumps in the simulation, so there are

--- a/src/core/functor.h
+++ b/src/core/functor.h
@@ -15,6 +15,8 @@
 #ifndef CORE_FUNCTOR_H_
 #define CORE_FUNCTOR_H_
 
+#include <utility>
+
 namespace bdm {
 
 // -----------------------------------------------------------------------------
@@ -28,7 +30,7 @@ class Functor {
 // -----------------------------------------------------------------------------
 /// Subclass of `bdm::Functor` that wraps a lambda with the same signature and
 /// forwards the call to the lambda. \n
-/// Together with the function `bdm::MakeFunctor` this class allows to define
+/// Together with the function `bdm::L2F` this class allows to define
 /// new functors exactly were they are needed and doesn't require the definition
 /// of a new class.
 template <typename TLambda>
@@ -40,37 +42,50 @@ struct LambdaFunctor<TReturn (TLambda::*)(TArgs...) const> final
     : public Functor<TReturn, TArgs...> {
   TLambda lambda;
 
-  LambdaFunctor(TLambda&& lambda) : lambda(lambda) {}
-  LambdaFunctor(TLambda lambda) : lambda(lambda) {}
-  LambdaFunctor(LambdaFunctor&& other) : lambda(std::move(other.lambda)) {}
+  LambdaFunctor(const TLambda& lambda) : lambda(lambda) {}
+  LambdaFunctor(const LambdaFunctor& other) : lambda(other.lambda) {}
   virtual ~LambdaFunctor() {}
 
-  TReturn operator()(TArgs... args) override { return lambda(args...); }
+  TReturn operator()(TArgs... args) override {
+    return lambda(std::forward<TArgs>(args)...);
+  }
+};
+
+/// \see `bdm::LambdaFunctor`
+template <typename TLambda, typename TReturn, typename... TArgs>
+struct LambdaFunctor<TReturn (TLambda::*)(TArgs...)> final
+    : public Functor<TReturn, TArgs...> {
+  TLambda lambda;
+
+  LambdaFunctor(const TLambda& lambda) : lambda(lambda) {}
+  LambdaFunctor(const LambdaFunctor& other) : lambda(other.lambda) {}
+  virtual ~LambdaFunctor() {}
+
+  TReturn operator()(TArgs... args) override {
+    return lambda(std::forward<TArgs>(args)...);
+  }
 };
 
 // -----------------------------------------------------------------------------
 /// Wraps a lambda inside a LambdaFunctor with the same signature as the lambda.
-/// Assume the following example using `MakeFunctor`
+/// Assume the following example using `L2F`
 ///
-///     void SomeFunction(...) {
-///       ...
-///       double threshold = 10;
-///       auto functor = MakeFunctor([&](Agent* neighbor, double
-///       squared_distance)) {
+///     void PrintSmallNeighbors(Agent* agent, double threshold) {
+///       auto functor = L2F([&](Agent* neighbor, double squared_distance)) {
 ///          if (neighbor->GetDiameter() < threshold) {
-///            std::cout << agent->GetUid() << std::endl;
+///            std::cout << neighbor->GetUid() << std::endl;
 ///          }
 ///       });
+///       auto* ctxt = Simulation::GetActive()->GetExecutionContext();
 ///       ctxt->ForEachNeighbor(functor, *agent);
-///       ...
 ///     }
 ///
-///  The base class of `functor` in the example above is
+/// The base class of `functor` in the example above is
 /// `Functor<void, Agent*, double>`\n
 /// The wrapped lambda is allowed to capture variables. \n
-/// Without bdm::LambdaFunctor and bdm::MakeFunctor the following code is needed
+/// Without bdm::LambdaFunctor and bdm::L2F the following code is needed
 /// to achieve the same result as above. Notice the extra class `MyFunctor` that
-/// has to be defined outside `SomeFunction`.
+/// has to be defined outside `PrintSmallNeighbors`.
 ///
 ///     class MyFunctor : public Functor<void, Agent*, double> {
 ///      public:
@@ -85,19 +100,15 @@ struct LambdaFunctor<TReturn (TLambda::*)(TArgs...) const> final
 ///       double threshold_;
 ///     };
 ///
-///     void SomeFunction(...) {
-///       ...
-///       double threshold = 10;
+///     void PrintSmallNeighbors(Agent* agent, double threshold) {
 ///       MyFunctor functor(threshold);
+///       auto* ctxt = Simulation::GetActive()->GetExecutionContext();
 ///       ctxt->ForEachNeighbor(functor, *agent);
-///       ...
 ///     }
 ///
 template <typename TLambda>
-LambdaFunctor<decltype(&TLambda::operator())> MakeFunctor(
-    const TLambda& lambda) {
-  LambdaFunctor<decltype(&TLambda::operator())> f(lambda);
-  return f;
+LambdaFunctor<decltype(&TLambda::operator())> L2F(const TLambda& l) {
+  return LambdaFunctor<decltype(&TLambda::operator())>(l);
 }
 
 }  // namespace bdm

--- a/src/core/resource_manager.cc
+++ b/src/core/resource_manager.cc
@@ -298,7 +298,7 @@ void ResourceManager::LoadBalance() {
   // synchronization overheads. The bdm memory allocator does not have this
   // issue.
   if (!minimize_memory) {
-    auto delete_functor = MakeFunctor([](Agent* agent) { delete agent; });
+    auto delete_functor = L2F([](Agent* agent) { delete agent; });
     ForEachAgentParallel(delete_functor);
   }
 

--- a/src/core/resource_manager.cc
+++ b/src/core/resource_manager.cc
@@ -187,10 +187,6 @@ void ResourceManager::ForEachAgentParallel(
   }
 }
 
-struct DeleteAgentsFunctor : public Functor<void, Agent*> {
-  void operator()(Agent* agent) { delete agent; }
-};
-
 struct LoadBalanceFunctor : public Functor<void, Iterator<AgentHandle>*> {
   bool minimize_memory;
   uint64_t offset;
@@ -302,7 +298,9 @@ void ResourceManager::LoadBalance() {
   // synchronization overheads. The bdm memory allocator does not have this
   // issue.
   if (!minimize_memory) {
-    DeleteAgentsFunctor delete_functor;
+    auto delete_functor = MakeFunctor([](Agent* agent){
+      delete agent;     
+    });
     ForEachAgentParallel(delete_functor);
   }
 

--- a/src/core/resource_manager.cc
+++ b/src/core/resource_manager.cc
@@ -298,9 +298,7 @@ void ResourceManager::LoadBalance() {
   // synchronization overheads. The bdm memory allocator does not have this
   // issue.
   if (!minimize_memory) {
-    auto delete_functor = MakeFunctor([](Agent* agent){
-      delete agent;     
-    });
+    auto delete_functor = MakeFunctor([](Agent* agent) { delete agent; });
     ForEachAgentParallel(delete_functor);
   }
 

--- a/test/unit/core/functor_test.cc
+++ b/test/unit/core/functor_test.cc
@@ -1,0 +1,71 @@
+// -----------------------------------------------------------------------------
+//
+//
+// Copyright (C) 2021 CERN & Newcastle University for the benefit of the
+// BioDynaMo collaboration. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// See the LICENSE file distributed with this work for details.
+// See the NOTICE file distributed with this work for additional information
+// regarding copyright ownership.
+//
+// -----------------------------------------------------------------------------
+
+#include "core/functor.h"
+#include <gtest/gtest.h>
+
+namespace bdm {
+
+// -----------------------------------------------------------------------------
+TEST(Lambda2Functor, Default) {
+  auto f = L2F([](int i, double d) { return i * d; });
+  auto result = f(3, 2.0);
+  EXPECT_NEAR(6, result, 1e-5);
+  bool is_base =
+      std::is_base_of<Functor<double, int, double>, decltype(f)>::value;
+  EXPECT_TRUE(is_base);
+}
+
+// -----------------------------------------------------------------------------
+TEST(Lambda2Functor, CaptureByReference) {
+  int i = 0;
+  auto f = L2F([&]() { return ++i; });
+  EXPECT_EQ(1, f());
+  EXPECT_EQ(1, i);
+  bool is_base = std::is_base_of<Functor<int>, decltype(f)>::value;
+  EXPECT_TRUE(is_base);
+}
+
+// -----------------------------------------------------------------------------
+TEST(Lambda2Functor, CaptureByValue) {
+  int i = 2;
+  auto f = L2F([=]() { return i; });
+  EXPECT_EQ(2, f());
+  EXPECT_EQ(2, i);
+  bool is_base = std::is_base_of<Functor<int>, decltype(f)>::value;
+  EXPECT_TRUE(is_base);
+}
+
+// -----------------------------------------------------------------------------
+TEST(Lambda2Functor, Mutable) {
+  int i = 1;
+  auto f = L2F([=]() mutable { return ++i; });
+  EXPECT_EQ(2, f());
+  EXPECT_EQ(1, i);
+  bool is_base = std::is_base_of<Functor<int>, decltype(f)>::value;
+  EXPECT_TRUE(is_base);
+}
+
+// -----------------------------------------------------------------------------
+TEST(Lambda2Functor, NoParamRetVoid) {
+  int i = 0;
+  auto f = L2F([&]() { ++i; });
+  f();
+  EXPECT_EQ(1, i);
+  bool is_base = std::is_base_of<Functor<void>, decltype(f)>::value;
+  EXPECT_TRUE(is_base);
+}
+
+}  // namespace bdm


### PR DESCRIPTION
`LambdaFunctor` is a subclass of `bdm::Functor` that wraps a lambda expression with the same signature and
forwards the call to it.
Together with the function `bdm::L2F` this class allows to define new functors exactly were they are needed and doesn't require the definition of a new class.

Assume the following example:
```
    void PrintSmallNeighbors(Agent* agent, double threshold) {
      auto functor = L2F([&](Agent* neighbor, double squared_distance)) {
         if (neighbor->GetDiameter() < threshold) {
           std::cout << neighbor->GetUid() << std::endl;
         }
      });
      auto* ctxt = Simulation::GetActive()->GetExecutionContext();
      ctxt->ForEachNeighbor(functor, *agent);
    }
```

The base class of `functor` in the example above is `Functor<void, Agent*, double>`
The wrapped lambda is allowed to capture variables.

Without `bdm::LambdaFunctor` and `bdm::L2F` the following code is needed
to achieve the same result as above. Notice the extra class `MyFunctor` that has to be defined outside `PrintSmallNeighbors`.
```
    class MyFunctor : public Functor<void, Agent*, double> {
     public:
      MyFunctor(double threshold) : threshold_(threshold) {}
      virtual ~MyFunctor() {}

      void operator()(Agent* neighbor, double squared_distance) override {
        if (neighbor->GetDiameter() < threshold_) {
          std::cout << agent->GetUid() << std::endl;
        }
      }

     private:
      double threshold_;
    };

    void PrintSmallNeighbors(Agent* agent, double threshold) {
      MyFunctor functor(threshold);
      auto* ctxt = Simulation::GetActive()->GetExecutionContext();
      ctxt->ForEachNeighbor(functor, *agent);
    }
```

