### PR TITLE
Fix typo in source instruction

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -756,5 +756,5 @@ endif()
 PRINT_LINE()
 MESSAGE("You have just finished to configure the BioDynaMo source.\n\
 Compile it by running \"${buildcmd}\".\n\
-Before using it do \". ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/thisbdm.sh.\"")
+Before using it do \". ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/thisbdm.sh\".")
 PRINT_LINE()


### PR DESCRIPTION
CMake message is now:
```
################################################################

You have just finished to configure the BioDynaMo source.
Compile it by running "ninja".
Before using it do ". /Users/tobias/biodynamo/build/bin/thisbdm.sh".

################################################################
```