### PR TITLE
Add check for existing directory

### DIFF
--- a/cli/biodynamo.py
+++ b/cli/biodynamo.py
@@ -13,7 +13,6 @@
 #
 # -----------------------------------------------------------------------------
 
-
 import argparse
 import sys
 from build_command import BuildCommand
@@ -22,53 +21,62 @@ from new_command import NewCommand
 from run_command import RunCommand
 from bdm_version import Version
 
-if __name__ == '__main__':
-    parser = argparse.ArgumentParser(prog='biodynamo',
-        description='This is the BioDynaMo command line interface. It guides '
-                    'you during the whole simulation workflow. From starting '
-                    'a new project, to compiling and executing your simulation.',
-        epilog='')
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        prog="biodynamo",
+        description="This is the BioDynaMo command line interface. It guides "
+        "you during the whole simulation workflow. From starting a new project,"
+        "to compiling and executing your simulation.",
+        epilog="",
+    )
 
-    sp = parser.add_subparsers(dest='cmd')
-    parser.add_argument('-v', '--version',
-                        action='store_true',
-                        help='Display BioDynaMo version')
-    parser.add_argument('--shortversion',
-                        action='store_true',
-                        help='Display BioDynaMo short version')
+    sp = parser.add_subparsers(dest="cmd")
+    parser.add_argument("-v",
+                        "--version",
+                        action="store_true",
+                        help="Display BioDynaMo version")
+    parser.add_argument("--shortversion",
+                        action="store_true",
+                        help="Display BioDynaMo short version")
 
-    build_sp = sp.add_parser('build', help='Builds the simulation binary')
+    build_sp = sp.add_parser("build", help="Builds the simulation binary")
 
-    clean_sp = sp.add_parser('clean', help='Removes all build files')
+    clean_sp = sp.add_parser("clean", help="Removes all build files")
 
-    demo_sp = sp.add_parser('demo', help='Creates pre-built demos.')
+    demo_sp = sp.add_parser("demo", help="Creates pre-built demos.")
 
-    new_sp = sp.add_parser('new', help='Creates a new simulation project. Creates '
-    'a template project, renames it to the given simulation name, '
-    'configures git.')
-    new_sp.add_argument('SIMULATION_NAME', type=str, help='simulation name help')
-    new_sp.add_argument('--github', action='store_true', help='Create a Github repository.'    )
+    new_sp = sp.add_parser(
+        "new",
+        help="Creates a new simulation project. Creates a template project, "
+        "renames it to the given simulation name, configures git.",
+    )
+    new_sp.add_argument("SIMULATION_NAME",
+                        type=str,
+                        help="simulation name help")
+    new_sp.add_argument("--github",
+                        action="store_true",
+                        help="Create a Github repository.")
 
-    run_sp = sp.add_parser('run', help='Executes the simulation')
+    run_sp = sp.add_parser("run", help="Executes the simulation")
 
     args, unknown = parser.parse_known_args()
 
-    if args.cmd == 'new':
+    if args.cmd == "new":
         if len(unknown) != 0:
             new_sp.print_help()
             sys.exit()
         NewCommand(args.SIMULATION_NAME, args.github)
-    elif args.cmd == 'build':
+    elif args.cmd == "build":
         if len(unknown) != 0:
             build_sp.print_help()
             sys.exit()
         BuildCommand()
-    elif args.cmd == 'clean':
+    elif args.cmd == "clean":
         if len(unknown) != 0:
             clean_sp.print_help()
             sys.exit()
         BuildCommand(clean=True, build=False)
-    elif args.cmd == 'demo':
+    elif args.cmd == "demo":
         demo_name = None
         destination = None
         if len(unknown) >= 1:
@@ -76,7 +84,7 @@ if __name__ == '__main__':
         if len(unknown) >= 2:
             destination = unknown[1]
         DemoCommand(demo_name, destination)
-    elif args.cmd == 'run':
+    elif args.cmd == "run":
         RunCommand(args=unknown)
     elif args.version:
         print(Version.string())

--- a/cli/build_command.py
+++ b/cli/build_command.py
@@ -37,28 +37,25 @@ def BuildCommand(clean=False, debug=False, build=True):
         if not os.path.exists(debug_dir):
             sp.check_output(["mkdir", debug_dir])
 
-        with open(debug_dir + '/cmake_output.log', "w") as file:
+        with open(debug_dir + "/cmake_output.log", "w") as file:
             try:
-                sp.check_call(
-                    ["cmake", "-B./" + build_dir, "-H."],
-                    stdout=file,
-                    stderr=file)
+                sp.check_call(["cmake", "-B./" + build_dir, "-H."],
+                              stdout=file,
+                              stderr=file)
             except sp.CalledProcessError as err:
                 Print.error(
-                "Failed to run CMake. Generating debug/cmake_output.log..."
+                    "Failed to run CMake. Generating debug/cmake_output.log..."
                 )
                 return
 
-        with open(debug_dir + '/make_output.log', "w") as file:
+        with open(debug_dir + "/make_output.log", "w") as file:
             try:
-                sp.check_call(
-                    ["make", "-C", build_dir],
-                    stdout=file,
-                    stderr=file)
+                sp.check_call(["make", "-C", build_dir],
+                              stdout=file,
+                              stderr=file)
             except sp.CalledProcessError as err:
                 Print.error(
-                "Compilation failed. Generating debug/make_output.log..."
-                )
+                    "Compilation failed. Generating debug/make_output.log...")
                 return
 
     elif build:
@@ -67,7 +64,8 @@ def BuildCommand(clean=False, debug=False, build=True):
             try:
                 sp.check_output(["cmake", "-B./" + build_dir, "-H."])
             except sp.CalledProcessError as err:
-                Print.error("Failed to run CMake. Check the debug output above.")
+                Print.error(
+                    "Failed to run CMake. Check the debug output above.")
                 sys.exit(1)
 
         try:

--- a/cli/common.py
+++ b/cli/common.py
@@ -17,8 +17,10 @@ import shutil
 
 from print_command import Print
 
+
 def CopySupportFiles(sim_name):
-    SUPPORT_DIR = os.path.join(os.environ['BDMSYS'], 'share', 'util', 'support_files')
+    SUPPORT_DIR = os.path.join(os.environ["BDMSYS"], "share", "util",
+                               "support_files")
     Print.new_step("Copy additional support files")
     for filename in os.listdir(SUPPORT_DIR):
         full_file_name = os.path.join(SUPPORT_DIR, filename)

--- a/cli/demo_command.py
+++ b/cli/demo_command.py
@@ -20,38 +20,38 @@ from print_command import Print
 from git_utils import InitializeNewGitRepo
 from common import CopySupportFiles
 
-
-DEMO_DIR = os.path.join(os.environ['BDMSYS'], 'demo')
-STYLE_DIR = os.path.join(os.environ['BDMSYS'], 'share', 'util', 'style_checks')
+DEMO_DIR = os.path.join(os.environ["BDMSYS"], "demo")
+STYLE_DIR = os.path.join(os.environ["BDMSYS"], "share", "util", "style_checks")
 KNOWN_DEMOS = os.listdir(DEMO_DIR)
 
 
 def DemoCommand(demo_name, destination=None):
     if not demo_name:
-        print('Usage: biodynamo demo <demo name> [target directory]')
-        print('Known demos:\n  {}'.format('\n  '.join(KNOWN_DEMOS)))
+        print("Usage: biodynamo demo <demo name> [target directory]")
+        print("Known demos:\n  {}".format("\n  ".join(KNOWN_DEMOS)))
         return
     if demo_name not in KNOWN_DEMOS:
-        Print.error('Demo name "{}" is not known.'.format(demo_name))
-        print('Known demos:\n  {}'.format('\n  '.join(KNOWN_DEMOS)))
+        Print.error("Demo name \"{}\" is not known.".format(demo_name))
+        print("Known demos:\n  {}".format("\n  ".join(KNOWN_DEMOS)))
         sys.exit(1)
     if destination is None:
-        destination = '.'
+        destination = "."
     if os.path.exists(destination):
         destination = os.path.join(destination, demo_name)
     if os.path.exists(destination):
-        Print.error('Destination directory "{}" exists.'.format(destination))
-        Print.error("Please remove it or create the demo in a different place.")
-        Print.error("Abort 'biodynamo demo {}'.".format(demo_name))
+        Print.error("Destination directory \"{}\" exists.".format(destination))
+        Print.error(
+            "Please remove it or create the demo in a different place.")
+        Print.error("Abort \"biodynamo demo {}\".".format(demo_name))
         sys.exit(2)
 
     src_dir = os.path.join(DEMO_DIR, demo_name)
-    print('Copying files from "{}" to "{}"...'.format(src_dir, destination))
+    print("Copying files from \"{}\" to \"{}\"...".format(src_dir, destination))
     shutil.copytree(src_dir, destination)
 
     CopySupportFiles(destination)
 
     InitializeNewGitRepo(destination)
 
-    Print.success('The demo "{}" has been created in "{}".'.format(
-            demo_name, destination))
+    Print.success("The demo \"{}\" has been created in \"{}\".".format(
+        demo_name, destination))

--- a/cli/demo_command.py
+++ b/cli/demo_command.py
@@ -41,6 +41,8 @@ def DemoCommand(demo_name, destination=None):
         destination = os.path.join(destination, demo_name)
     if os.path.exists(destination):
         Print.error('Destination directory "{}" exists.'.format(destination))
+        Print.error("Please remove it or create the demo in a different place.")
+        Print.error("Abort 'biodynamo demo {}'.".format(demo_name))
         sys.exit(2)
 
     src_dir = os.path.join(DEMO_DIR, demo_name)

--- a/cli/git_utils.py
+++ b/cli/git_utils.py
@@ -21,29 +21,35 @@ import getpass
 import subprocess as sp
 from print_command import Print
 
+
 def InitializeNewGitRepo(sim_name):
     Print.new_step("Initialize new git repository")
     sp.check_output(["git", "init"], cwd=sim_name)
 
     # check if user name and email are set
     try:
-        out = sp.check_output(["git", "config", "user.name"], cwd=sim_name).decode("utf-8")
+        out = sp.check_output(["git", "config", "user.name"],
+                              cwd=sim_name).decode("utf-8")
     except sp.CalledProcessError as err:
         # User name not set
         print("Your git user name is not set.")
         response = input("Please enter your name (e.g. Mona Lisa): ")
-        out = sp.check_output(["git", "config", "user.name", response], cwd=sim_name)
+        out = sp.check_output(["git", "config", "user.name", response],
+                              cwd=sim_name)
 
     try:
-        out = sp.check_output(["git", "config", "user.email"], cwd=sim_name).decode("utf-8")
+        out = sp.check_output(["git", "config", "user.email"],
+                              cwd=sim_name).decode("utf-8")
     except sp.CalledProcessError as err:
         # User name not set
         print("Your git user e-mail is not set.")
         response = input("Please enter your e-mail address: ")
-        out = sp.check_output(["git", "config", "user.email", response], cwd=sim_name)
+        out = sp.check_output(["git", "config", "user.email", response],
+                              cwd=sim_name)
 
     sp.check_output(["git", "add", "."], cwd=sim_name)
-    sp.check_output(["git", "commit", "-m", "\"Initial commit\""], cwd=sim_name)
+    sp.check_output(["git", "commit", "-m", '"Initial commit"'], cwd=sim_name)
+
 
 def CreateNewGithubRepository(sim_name):
     Print.new_step("Create Github repository")
@@ -52,16 +58,20 @@ def CreateNewGithubRepository(sim_name):
 
     # create new github repo
     try:
-        data = {"name": sim_name , "description": "Simulation powered by BioDynaMo"}
-        headers = {'Content-Type': 'application/json'}
-        bytes = json.dumps(data).encode('utf-8')
+        data = {
+            "name": sim_name,
+            "description": "Simulation powered by BioDynaMo"
+        }
+        headers = {"Content-Type": "application/json"}
+        bytes = json.dumps(data).encode("utf-8")
         url = "https://api.github.com/user/repos"
 
         request = urllib.request.Request(url, data=bytes, headers=headers)
 
-        credentials = ('%s:%s' % (gh_user, gh_pass))
-        encoded_credentials = base64.b64encode(credentials.encode('ascii'))
-        request.add_header('Authorization', 'Basic %s' % encoded_credentials.decode("ascii"))
+        credentials = "%s:%s" % (gh_user, gh_pass)
+        encoded_credentials = base64.b64encode(credentials.encode("ascii"))
+        request.add_header("Authorization",
+                           "Basic %s" % encoded_credentials.decode("ascii"))
         result = urllib.request.urlopen(request)
     except urllib.error.HTTPError as err:
         Print.error("Github repository creation failed.")
@@ -71,7 +81,9 @@ def CreateNewGithubRepository(sim_name):
     # Connect github repository with local
     try:
         repo_url = "https://github.com/" + gh_user + "/" + sim_name + ".git"
-        sp.check_output(["git", "remote", "add", "origin", repo_url], cwd=sim_name)
+        sp.check_output(["git", "remote", "add", "origin", repo_url],
+                        cwd=sim_name)
     except sp.CalledProcessError as err:
-        Print.error("Error: Setting remote github url ({0}) failed.".format(repo_url))
+        Print.error(
+            "Error: Setting remote github url ({0}) failed.".format(repo_url))
         CleanupOnError(sim_name)

--- a/cli/new_command.py
+++ b/cli/new_command.py
@@ -31,11 +31,9 @@ def ValidateSimName(sim_name):
         sys.exit(1)
     if os.path.isdir(sim_name):
         Print.error("The directory '{}' already exists.".format(sim_name))
-        Print.error("Do you want to overwrite it? [y/n]")
-        if input().lower() == "y":
-            sp.check_output(["rm", "-rf", sim_name])
-        else:
-            sys.exit(0)
+        Print.error("Please remove it or choose a different name.")
+        Print.error("Abort 'biodynamo new {}'.".format(sim_name))
+        sys.exit(1)
 
 ## Removes any created files during NewCommand and exits the program
 def CleanupOnError(sim_name):

--- a/cli/new_command.py
+++ b/cli/new_command.py
@@ -22,18 +22,21 @@ from print_command import Print
 from git_utils import *
 from common import CopySupportFiles
 
+
 def ValidateSimName(sim_name):
     pattern = re.compile("^[a-zA-Z]+[a-zA-Z0-9\-_]+$")
     if not pattern.match(sim_name):
-        Print.error("Error: simulation name '{0}' is not valid.".format(sim_name))
+        Print.error(
+            "Error: simulation name \"{}\" is not valid.".format(sim_name))
         Print.error("       Allowed characters are a-z A-Z 0-9 - and _")
         Print.error("       Must start with a-z or A-Z")
         sys.exit(1)
     if os.path.isdir(sim_name):
-        Print.error("The directory '{}' already exists.".format(sim_name))
+        Print.error("The directory \"{}\" already exists.".format(sim_name))
         Print.error("Please remove it or choose a different name.")
-        Print.error("Abort 'biodynamo new {}'.".format(sim_name))
+        Print.error("Abort \"biodynamo new {}\".".format(sim_name))
         sys.exit(1)
+
 
 ## Removes any created files during NewCommand and exits the program
 def CleanupOnError(sim_name):
@@ -43,10 +46,11 @@ def CleanupOnError(sim_name):
         Print.error("Error: Failed to remove folder {0}".format(sim_name))
     sys.exit(1)
 
+
 def CopyTemplate(sim_name):
     Print.new_step("Copy simulation template")
     try:
-        src_path = "{0}/simulation-template".format(os.environ['BDMSYS'])
+        src_path = "{0}/simulation-template".format(os.environ["BDMSYS"])
         sp.check_output(["cp", "-R", src_path, "./{0}".format(sim_name)])
     except sp.CalledProcessError as err:
         Print.error("Error while copying the template project.")
@@ -55,34 +59,49 @@ def CopyTemplate(sim_name):
         # we must not remove it
         sys.exit(1)
 
+
 def ModifyFileContent(filename, fn):
-	with open(filename) as f:
-		content = f.read()
+    with open(filename) as f:
+        content = f.read()
 
-	content = fn(content)
+    content = fn(content)
 
-	with open(filename, "w") as f:
-		f.write(content)
+    with open(filename, "w") as f:
+        f.write(content)
+
 
 def CustomizeFiles(sim_name):
     Print.new_step("Customize files")
     try:
         # README.md
-        ModifyFileContent(sim_name + "/README.md", lambda content: "# " + sim_name + "\n")
+        ModifyFileContent(sim_name + "/README.md",
+                          lambda content: "# " + sim_name + "\n")
 
         # CMakelists.txt
-        ModifyFileContent(sim_name + "/CMakeLists.txt", lambda content: content.replace("my-simulation", sim_name))
+        ModifyFileContent(
+            sim_name + "/CMakeLists.txt",
+            lambda content: content.replace("my-simulation", sim_name),
+        )
 
         # source files
         include_guard = sim_name.upper().replace("-", "_") + "_H_"
-        ModifyFileContent(sim_name + "/src/my-simulation.h", lambda c: c.replace("MY_SIMULATION_H_", include_guard))
-        ModifyFileContent(sim_name + "/src/my-simulation.cc", lambda c: c.replace("my-simulation", sim_name))
+        ModifyFileContent(
+            sim_name + "/src/my-simulation.h",
+            lambda c: c.replace("MY_SIMULATION_H_", include_guard),
+        )
+        ModifyFileContent(
+            sim_name + "/src/my-simulation.cc",
+            lambda c: c.replace("my-simulation", sim_name),
+        )
         #   rename
-        os.rename(sim_name + "/src/my-simulation.h", sim_name + "/src/" + sim_name + ".h")
-        os.rename(sim_name + "/src/my-simulation.cc", sim_name + "/src/" + sim_name + ".cc")
+        os.rename(sim_name + "/src/my-simulation.h",
+                  sim_name + "/src/" + sim_name + ".h")
+        os.rename(sim_name + "/src/my-simulation.cc",
+                  sim_name + "/src/" + sim_name + ".cc")
     except:
         Print.error("Error: File customizations failed")
         CleanupOnError(sim_name)
+
 
 def NewCommand(sim_name, github):
     if github:
@@ -99,5 +118,5 @@ def NewCommand(sim_name, github):
         CreateNewGithubRepository(sim_name)
 
     Print.success(sim_name + " has been created successfully!")
-    print('To compile and run this simulation, change the directory by calling '
-            '"cd %s"' % (sim_name))
+    print("To compile and run this simulation, change the directory by calling "
+          "\"cd %s\"" % (sim_name))

--- a/cli/new_command.py
+++ b/cli/new_command.py
@@ -29,6 +29,13 @@ def ValidateSimName(sim_name):
         Print.error("       Allowed characters are a-z A-Z 0-9 - and _")
         Print.error("       Must start with a-z or A-Z")
         sys.exit(1)
+    if os.path.isdir(sim_name):
+        Print.error("The directory '{}' already exists.".format(sim_name))
+        Print.error("Do you want to overwrite it? [y/n]")
+        if input().lower() == "y":
+            sp.check_output(["rm", "-rf", sim_name])
+        else:
+            sys.exit(0)
 
 ## Removes any created files during NewCommand and exits the program
 def CleanupOnError(sim_name):

--- a/cli/print_command.py
+++ b/cli/print_command.py
@@ -12,17 +12,18 @@
 #
 # -----------------------------------------------------------------------------
 
+
 class Print:
-    PURPLE = '\033[95m'
-    CYAN = '\033[96m'
-    DARKCYAN = '\033[36m'
-    BLUE = '\033[94m'
-    GREEN = '\033[92m'
-    YELLOW = '\033[93m'
-    RED = '\033[91m'
-    BOLD = '\033[1m'
-    UNDERLINE = '\033[4m'
-    END = '\033[0m'
+    PURPLE = "\033[95m"
+    CYAN = "\033[96m"
+    DARKCYAN = "\033[36m"
+    BLUE = "\033[94m"
+    GREEN = "\033[92m"
+    YELLOW = "\033[93m"
+    RED = "\033[91m"
+    BOLD = "\033[1m"
+    UNDERLINE = "\033[4m"
+    END = "\033[0m"
 
     @staticmethod
     def success(message):
@@ -38,4 +39,4 @@ class Print:
 
     @staticmethod
     def new_step(message):
-        print('\n' + Print.BOLD + Print.BLUE + str(message) + Print.END)
+        print("\n" + Print.BOLD + Print.BLUE + str(message) + Print.END)

--- a/cli/run_command.py
+++ b/cli/run_command.py
@@ -18,27 +18,31 @@ from print_command import Print
 from build_command import BuildCommand
 from util import GetBinaryName
 
+
 ## The BioDynaMo CLI command to run a simulation
 ##
 ## @param      sim_name  The simulation name
 ##
 def RunCommand(args, debug=False):
     sim_name = GetBinaryName()
-    args_str = ' '.join(args)
+    args_str = " ".join(args)
     cmd = "./build/" + sim_name
-    if platform.system() == 'Darwin':
-      launcher = os.environ['BDMSYS'] + '/bin/launcher.sh'
+    if platform.system() == "Darwin":
+        launcher = os.environ["BDMSYS"] + "/bin/launcher.sh"
     else:
-      launcher = ""
+        launcher = ""
 
     try:
         BuildCommand()
-        Print.new_step("Run " + sim_name + ' ' + args_str)
+        Print.new_step("Run " + sim_name + " " + args_str)
         if debug:
-            sp.check_output([launcher + " " + cmd, "&>", "debug/runtime_output.log"])
+            sp.check_output(
+                [launcher + " " + cmd, "&>", "debug/runtime_output.log"])
         else:
-            print(sp.check_output([launcher + " " + cmd, args_str],
-                                stderr=sp.STDOUT, shell=True).decode('utf-8'))
+            print(
+                sp.check_output([launcher + " " + cmd, args_str],
+                                stderr=sp.STDOUT,
+                                shell=True).decode("utf-8"))
             Print.success("Finished successfully")
     except sp.CalledProcessError as err:
         print(err.output.decode("utf-8"))

--- a/cli/util.py
+++ b/cli/util.py
@@ -18,8 +18,8 @@ import re
 import subprocess as sp
 import sys
 
+
 def GetBinaryName():
     with open("CMakeLists.txt") as f:
         content = f.read()
-        return re.search('project\((.*)\)', content).group(1)
-
+        return re.search("project\((.*)\)", content).group(1)


### PR DESCRIPTION
The command `biodynamo new <project>` had a bug, i.e. running it twice with the same `<project>` would just delete the existing folder and crash. Now, it checks if the project exists and, if so, asks the user to overwrite or not.