### PR TITLE
WIP: Add Googletest support for template

### DIFF
--- a/cli/biodynamo.py
+++ b/cli/biodynamo.py
@@ -19,6 +19,7 @@ from build_command import BuildCommand
 from demo_command import DemoCommand
 from new_command import NewCommand
 from run_command import RunCommand
+from test_command import TestCommand
 from bdm_version import Version
 
 if __name__ == "__main__":
@@ -59,6 +60,9 @@ if __name__ == "__main__":
 
     run_sp = sp.add_parser("run", help="Executes the simulation")
 
+    test_sp = sp.add_parser("test",
+                            help="Executes the unit-tests of a BioDynaMo sim.")
+
     args, unknown = parser.parse_known_args()
 
     if args.cmd == "new":
@@ -86,6 +90,8 @@ if __name__ == "__main__":
         DemoCommand(demo_name, destination)
     elif args.cmd == "run":
         RunCommand(args=unknown)
+    elif args.cmd == "test":
+        TestCommand()
     elif args.version:
         print(Version.string())
         sys.exit()

--- a/cli/new_command.py
+++ b/cli/new_command.py
@@ -31,6 +31,11 @@ def ValidateSimName(sim_name):
         Print.error("       Allowed characters are a-z A-Z 0-9 - and _")
         Print.error("       Must start with a-z or A-Z")
         sys.exit(1)
+    if sim_name.lower() == "test":
+        Print.error("The directory name \"test\" is not allowed because it")
+        Print.error("causes problems with the unit-test compilation.")
+        Print.error("Please choose a different name.")
+        sys.exit(1)
     if os.path.isdir(sim_name):
         Print.error("The directory \"{}\" already exists.".format(sim_name))
         Print.error("Please remove it or choose a different name.")
@@ -74,8 +79,10 @@ def CustomizeFiles(sim_name):
     Print.new_step("Customize files")
     try:
         # README.md
-        ModifyFileContent(sim_name + "/README.md",
-                          lambda content: "# " + sim_name + "\n")
+        ModifyFileContent(
+            sim_name + "/README.md",
+            lambda content: content.replace("my-simulation", sim_name),
+        )
 
         # CMakelists.txt
         ModifyFileContent(

--- a/cli/test_command.py
+++ b/cli/test_command.py
@@ -1,0 +1,28 @@
+# -----------------------------------------------------------------------------
+#
+# Copyright (C) 2021 CERN & Newcastle University for the benefit of the
+# BioDynaMo collaboration. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+#
+# See the LICENSE file distributed with this work for details.
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
+#
+# -----------------------------------------------------------------------------
+
+import os
+import subprocess as sp
+
+
+## The BioDynaMo CLI command to execute the unit-tests created by default with
+## the simulation template.
+def TestCommand():
+    cwd = os.getcwd()
+    if cwd.split("/")[-1] == "build":
+        sp.run("ctest", shell=True)
+    else:
+        os.chdir("build")
+        sp.run("ctest", shell=True)
+        os.chdir(cwd)

--- a/cmake/Testing.cmake
+++ b/cmake/Testing.cmake
@@ -29,7 +29,7 @@ ExternalProject_Add(
   # Ugly but necessary, in future versions one can use ${binary_dir}
   # in BUILD_BYPRODUCTS
   #BUILD_BYPRODUCTS "${binary_dir}/libgtest.a"
-  # BUILD_BYPRODUCTS "${CMAKE_BINARY_DIR}/gtest/src/gtest-build/libgtest.a"
+  BUILD_BYPRODUCTS "${CMAKE_BINARY_DIR}/gtest/src/gtest-build/libgtest.a"
 )
 ExternalProject_Get_Property(gtest source_dir binary_dir)
 

--- a/cmake/Testing.cmake
+++ b/cmake/Testing.cmake
@@ -23,11 +23,13 @@ ExternalProject_Add(
   CMAKE_CACHE_ARGS
     -DCMAKE_CXX_COMPILER:FILEPATH=${CMAKE_CXX_COMPILER}
     -DCMAKE_C_COMPILER:FILEPATH=${CMAKE_C_COMPILER}
-    INSTALL_COMMAND cp -r "${CMAKE_CURRENT_BINARY_DIR}/gtest/src/gtest/include" "${CMAKE_CURRENT_BINARY_DIR}/include"
+  INSTALL_COMMAND cp -r "${CMAKE_CURRENT_BINARY_DIR}/gtest/src/gtest/include" "${CMAKE_CURRENT_BINARY_DIR}/include" &&
+    cp "${CMAKE_CURRENT_BINARY_DIR}/gtest/src/gtest-build/libgtest.a" "${CMAKE_CURRENT_BINARY_DIR}/lib/" &&
+    cp "${CMAKE_CURRENT_BINARY_DIR}/gtest/src/gtest-build/libgtest_main.a" "${CMAKE_CURRENT_BINARY_DIR}/lib/" 
   # Ugly but necessary, in future versions one can use ${binary_dir}
   # in BUILD_BYPRODUCTS
   #BUILD_BYPRODUCTS "${binary_dir}/libgtest.a"
-  BUILD_BYPRODUCTS "${CMAKE_BINARY_DIR}/gtest/src/gtest-build/libgtest.a"
+  # BUILD_BYPRODUCTS "${CMAKE_BINARY_DIR}/gtest/src/gtest-build/libgtest.a"
 )
 ExternalProject_Get_Property(gtest source_dir binary_dir)
 

--- a/cmake/UseBioDynaMo.cmake.in
+++ b/cmake/UseBioDynaMo.cmake.in
@@ -242,6 +242,26 @@ if(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
 endif()
 include("${BDMSYS}/share/cmake/SetCompilerFlags.cmake")
 
+# -------------- function to compile tests in derived work ---------------------
+function(bdm_add_test TARGET)
+  cmake_parse_arguments(ARG "" "" "SOURCES;LIBRARIES" ${ARGN} )
+  # Create a libgtest target to be used as a dependency by test program
+  add_library(libgtest_main IMPORTED STATIC GLOBAL)
+  add_dependencies(libgtest_main gtest_main)
+  set_target_properties(libgtest_main PROPERTIES
+      IMPORTED_LOCATION "$ENV{BDMSYS}/lib/libgtest_main.a"
+      IMPORTED_LINK_INTERFACE_LIBRARIES "${CMAKE_THREAD_LIBS_INIT}"
+  )
+  add_library(libgtest IMPORTED STATIC GLOBAL)
+  add_dependencies(libgtest gtest_main)
+  set_target_properties(libgtest PROPERTIES
+      IMPORTED_LOCATION "$ENV{BDMSYS}/lib/libgtest.a"
+      IMPORTED_LINK_INTERFACE_LIBRARIES "${CMAKE_THREAD_LIBS_INIT}"
+  )
+  add_executable(${TARGET} ${ARG_SOURCES})
+  target_link_libraries(${TARGET} ${ARG_LIBRARIES}  libgtest libgtest_main)
+endfunction(bdm_add_test)
+
 # -------------------- includes -----------------------------------------------
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${BDMSYS}/share/cmake")
 include("${BDMSYS}/share/cmake/BioDynaMo.cmake")

--- a/util/simulation-template/CMakeLists.txt
+++ b/util/simulation-template/CMakeLists.txt
@@ -11,18 +11,38 @@
 # regarding copyright ownership.
 #
 # -----------------------------------------------------------------------------
-cmake_minimum_required(VERSION 3.2.0)
-
+cmake_minimum_required(VERSION 3.19.3)
 project(my-simulation)
 
-find_package(BioDynaMo REQUIRED)
-include(${BDM_USE_FILE})
-include_directories("src")
+# BioDynaMo curretly uses the C++14 standard.
+set(CMAKE_CXX_STANDARD 14)
 
-file(GLOB_RECURSE HEADERS src/*.h)
-file(GLOB_RECURSE SOURCES src/*.cc)
+# Use BioDynaMo in this project.
+find_package(BioDynaMo REQUIRED)
+
+# See UseBioDynaMo.cmake in your BioDynaMo build folder for details.
+# Note that BioDynaMo provides gtest header/libraries in its include/lib dir.
+include(${BDM_USE_FILE})
+
+# Consider all files in src/ for BioDynaMo simulation.
+include_directories("src")
+file(GLOB_RECURSE PROJECT_HEADERS src/*.h)
+file(GLOB_RECURSE PROJECT_SOURCES src/*.cc)
 
 bdm_add_executable(my-simulation
-                   HEADERS ${HEADERS}
-                   SOURCES ${SOURCES}
+                   HEADERS ${PROJECT_HEADERS}
+                   SOURCES ${PROJECT_SOURCES}
                    LIBRARIES ${BDM_REQUIRED_LIBRARIES})
+
+# Consider all files in test/ for GoogleTests.
+include_directories("test")
+file(GLOB_RECURSE TEST_SOURCES test/*.cc)
+
+bdm_add_test(my-simulation-test
+             SOURCES ${TEST_SOURCES}
+             LIBRARIES ${BDM_REQUIRED_LIBRARIES})
+
+# Instructions for GoogleTest
+enable_testing()
+include(GoogleTest)
+gtest_discover_tests(my-simulation-test)

--- a/util/simulation-template/README.md
+++ b/util/simulation-template/README.md
@@ -1,2 +1,72 @@
-# simulation-templates
-Repository for BioDynaMo simulation templates
+# my-simulation
+
+This repository contains a template for a BioDynaMo simulation. It consists of 
+the two folders `src/` and `test/`. The `src/` folder contains the simulation. 
+All custom classes and functions that users create to simulate a system 
+should ideally end up here. The `test/` folder contains examples for unit tests.
+We strongly encourage our users to follow a test driven development process, 
+i.e. create unit tests for all fundamental building blocks of your simulation.
+By doing so, you can always be sure that a certain function or a class behaves 
+as you expect it to. The `.cc` files in `test/` are automatically linked against 
+the GoogleTest framework. For more information, please consult the appropriate
+[GitHub](https://github.com/google/googletest) page or the 
+[Googletest primer](https://google.github.io/googletest/primer.html).
+
+Whenever you interact with this repository, make sure you have sourced BioDynaMo
+correctly. If it's sourced, you'll see a `[bdm-1.X.YY]` in your terminal. 
+Anytime that you open a new terminal, you have to source it again. 
+```bash
+. <path_to_biodynamo>/build/bin/thisbdm.sh
+```
+
+In the following, we want to explain how to build, run, and test your 
+simulation.
+
+## 1. Building the simulation and the tests
+
+Option 1:
+```bash
+biodynamo build
+```
+
+Option 2:
+```bash
+mkdir build && cd build
+cmake ..
+make -j <number_of_processes_for_build>
+```
+
+## 2. Running the simulation
+
+Before running the simulation, you need to build it. If you haven't done so, 
+please go back to step 1.
+
+Option 1:
+```bash
+biodynamo run
+```
+
+Option 2:
+```
+./build/my-simulation
+```
+
+## 3. Execute the unit tests
+
+Before running the unit tests, you need to build them. If you haven't done so, 
+please go back to step 1.
+
+Option 1:
+```bash
+biodynamo test
+```
+
+Option 2:
+```bash
+./build/my-simulation-test
+```
+
+Option 2:
+```bash
+cd build && ctest
+```

--- a/util/simulation-template/test/test-suit-agent.cc
+++ b/util/simulation-template/test/test-suit-agent.cc
@@ -1,0 +1,70 @@
+// -----------------------------------------------------------------------------
+//
+// Copyright (C) 2021 CERN & Newcastle University for the benefit of the
+// BioDynaMo collaboration. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// See the LICENSE file distributed with this work for details.
+// See the NOTICE file distributed with this work for additional information
+// regarding copyright ownership.
+//
+// -----------------------------------------------------------------------------
+
+#include <gtest/gtest.h>
+#include "biodynamo.h"
+
+// Googletest in combination with the provided CMakeLists.txt allows you to
+// define tests in arbitrary .cc files in the `test/` folder. We propose
+// this file to test the agent. The examples below are not necessary because
+// they are tested in BioDynaMo itself. It should serve as an inspiration for
+// testing user-defined, customn behaviours or similar things.
+
+#define TEST_NAME typeid(*this).name()
+
+namespace bdm {
+
+// Test if we can add agents to the simulation
+TEST(AgentTest, AddAgentsToSimulation) {
+  // Create simulation
+  Simulation simulation(TEST_NAME);
+
+  // Add some cells to the simulation
+  auto* rm = simulation.GetResourceManager();
+  for (int i = 0; i < 20; i++) {
+    auto* cell = new Cell(30);
+    rm->AddAgent(cell);
+  }
+
+  // Test if all 20 cells are in the simulation
+  auto no_cells = rm->GetNumAgents();
+  EXPECT_EQ(20, no_cells);
+}
+
+// Test if our GrothDevision behaviour increases the cell volume as expected
+TEST(AgentTest, CellGrowth) {
+  // Create simulation
+  Simulation simulation(TEST_NAME);
+
+  // Add one growing cell to the simulation
+  auto* rm = simulation.GetResourceManager();
+  auto* cell = new Cell(30);
+  cell->AddBehavior(new GrowthDivision());
+  const AgentPointer<Cell> cell_ptr = cell->GetAgentPtr<Cell>();
+  rm->AddAgent(cell);
+
+  // Get cell volume at the beginning
+  const double volume_1 = cell_ptr->GetVolume();
+
+  // Simulate for 3 timesteps
+  simulation.Simulate(3);
+
+  // Get cell volume at the beginning after 3 timesteps
+  const double volume_2 = cell_ptr->GetVolume();
+
+  // Test if cell volume has increased
+  EXPECT_LT(volume_1, volume_2);
+}
+
+}  // namespace bdm

--- a/util/simulation-template/test/test-suit-util.cc
+++ b/util/simulation-template/test/test-suit-util.cc
@@ -1,0 +1,54 @@
+// -----------------------------------------------------------------------------
+//
+// Copyright (C) 2021 CERN & Newcastle University for the benefit of the
+// BioDynaMo collaboration. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// See the LICENSE file distributed with this work for details.
+// See the NOTICE file distributed with this work for additional information
+// regarding copyright ownership.
+//
+// -----------------------------------------------------------------------------
+
+#include <gtest/gtest.h>
+
+// Googletest in combination with the provided CMakeLists.txt allows you to
+// define tests in arbitrary .cc files in the `test/` folder. We propose
+// this file to test some general utilities.
+
+// Example function `SquareMax`:
+// Computes the square of `to_square` but output is bounded by `upper_bound`.
+// Typically this function would occur somewhere in `src/` and we would include
+// it here. For simplicity, we now define it here.
+double SquareMax(double to_square, double upper_bound) {
+  double square = to_square * to_square;
+  if (square < upper_bound) {
+    return square;
+  } else {
+    return upper_bound;
+  }
+}
+
+// Show how to compare two stings
+TEST(UtilTest, StringTest) {
+  // Expect two strings not to be equal
+  EXPECT_STRNE("hello", "world");
+}
+
+// Show how to compare two numbers
+TEST(UtilTest, NumberTest) {
+  // Expect equality
+  EXPECT_EQ(7 * 6, 42);
+}
+
+// Test if our function SquareMax behaves as expected
+TEST(UtilTest, SquareMaxTest) {
+  // Expect equality for the following
+  EXPECT_EQ(1.0, SquareMax(1.0, 10.0));
+  EXPECT_EQ(4.0, SquareMax(2.0, 10.0));
+  EXPECT_EQ(9.0, SquareMax(3.0, 10.0));
+  EXPECT_EQ(10.0, SquareMax(4.0, 10.0));
+  EXPECT_EQ(10.0, SquareMax(5.0, 10.0));
+}


### PR DESCRIPTION
As discussed, the idea is to support Googletests in the template such that users can easily write (unit) tests. With this low entry barrier, we motivate them to use a test-driven development approach. Tests are very crucial especially when dealing with complex simulations where it is very hard to understand where problems arise. It will help them to obtain more reliable results with BDM.

The changes in this pull request are the following:

1. The build system now moves `libgtest.a` and `libgtest_main.a` to the `build/lib` folder such that people using BioDynaMo in their project can access the libraries. 
2. Extended the CLI with a `biodynamo test` command
3. Added a function `bdm_add_test` for test compilation to `UseBioDynaMo.cmake.in`
4. Modified the simulation template by extending the README, updating it's build instructions to account for googletests, and added some dummy tests as example.

Let me know what you think about that.