### PR TITLE
Fix Norm and Normalize for zero vector

### DIFF
--- a/src/core/container/math_array.h
+++ b/src/core/container/math_array.h
@@ -24,6 +24,7 @@
 #include <utility>
 
 #include "core/util/root.h"
+#include "core/util/log.h"
 
 namespace bdm {
 
@@ -343,13 +344,17 @@ class MathArray {  // NOLINT
     }
     result = std::sqrt(result);
 
-    return result == 0 ? 1.0 : result;
+    return result;
   }
 
   /// Normalize the array. It will be done in-place.
   /// \return the normalized array.
   MathArray& Normalize() {
     T norm = Norm();
+    if (norm == 0){
+      Log::Fatal("MathArray::Normalize","You tried to normalize a zero vector. " 
+      "This cannot be done. Exiting.");
+    }
 #pragma omp simd
     for (size_t i = 0; i < N; i++) {
       data_[i] /= norm;

--- a/test/unit/core/container/math_array_test.cc
+++ b/test/unit/core/container/math_array_test.cc
@@ -115,6 +115,15 @@ TEST(MathArray, complex_operations) {
   ASSERT_EQ(c.EntryWiseProduct(c), entrywise_result);
 }
 
+TEST(MathArray, NomalizeZeroVectorDeath) {
+  EXPECT_DEATH_IF_SUPPORTED(
+      {
+        Double3 x({0.0, 0.0, 0.0});
+        x.Normalize();
+      },
+      ".*You tried to normalize a zero vector..*");
+}
+
 #ifdef USE_DICT
 TEST_F(IOTest, MathArray) {
   MathArray<double, 4> test{0.5, -1, 10, 500};

--- a/test/unit/core/container/math_array_test.cc
+++ b/test/unit/core/container/math_array_test.cc
@@ -110,7 +110,7 @@ TEST(MathArray, complex_operations) {
   EXPECT_NEAR(0.5345224838248488374, a[1], abs_error<double>::value);
   EXPECT_NEAR(0.8017837257372732561, a[2], abs_error<double>::value);
 
-  ASSERT_EQ(b.Norm(), 1);
+  ASSERT_EQ(b.Norm(), 0.0);
 
   ASSERT_EQ(c.EntryWiseProduct(c), entrywise_result);
 }

--- a/test/unit/core/model_initializer_test.cc
+++ b/test/unit/core/model_initializer_test.cc
@@ -36,7 +36,7 @@ void Verify(Simulation* sim, uint64_t num_agents,
     uint64_t cnt = 0;
     rm->ForEachAgent([&](Agent* agent, AgentHandle) {
       auto diff = pos - agent->GetPosition();
-      if (std::abs(diff.Norm() - 1) < 1e-5) {
+      if (diff.Norm() < 1e-5) {
         cnt++;
       }
     });


### PR DESCRIPTION
The `MathArray.Norm()` method returned 1.0 for the zero vector which may not be what users expect. Now it returns 0. As a consequence, `MathArray.Normalize()` will not work for zero vectors any longer which is why we now throw a **_Fatal_** if someone tries to normalize the zero vector. See discussion on slack.