### PR TITLE
Improve copy command for gtest files

### DIFF
--- a/cmake/Testing.cmake
+++ b/cmake/Testing.cmake
@@ -23,7 +23,7 @@ ExternalProject_Add(
   CMAKE_CACHE_ARGS
     -DCMAKE_CXX_COMPILER:FILEPATH=${CMAKE_CXX_COMPILER}
     -DCMAKE_C_COMPILER:FILEPATH=${CMAKE_C_COMPILER}
-    INSTALL_COMMAND cp -r "${CMAKE_CURRENT_BINARY_DIR}/gtest/src/gtest/include" "${CMAKE_CURRENT_BINARY_DIR}/include"
+    INSTALL_COMMAND cp -a "${CMAKE_CURRENT_BINARY_DIR}/gtest/src/gtest/include/." "${CMAKE_CURRENT_BINARY_DIR}/include"
   # Ugly but necessary, in future versions one can use ${binary_dir}
   # in BUILD_BYPRODUCTS
   #BUILD_BYPRODUCTS "${binary_dir}/libgtest.a"


### PR DESCRIPTION
On some systems copying $GTEST_SRC/include would not copy the
contents of the include directory, but rather the include
directory itself - resulting in: biodynamo/build/include/include

This would in return result in Cling not being able to find the
gtest headers and cause a segfault.

The improved copy command will always copy the contents correctly.