### PR TITLE
BugFix for Diffusion Grid Initialization

### DIFF
--- a/src/core/container/parallel_resize_vector.h
+++ b/src/core/container/parallel_resize_vector.h
@@ -145,15 +145,20 @@ class ParallelResizeVector {
   }
 
   ParallelResizeVector& operator=(const ParallelResizeVector& other) {
-    free(data_);
-    data_ = nullptr;
+    if (&other == this) {
+      return *this;
+    }
+
+    clear();
+    // the following function call ensures that at least other.capacity_
+    // elements can be stored. If capacity_ > other.capacity_
+    // the container is NOT shrank.
     reserve(other.capacity_);
     size_ = other.size_;
-    capacity_ = other.capacity_;
 
 #pragma omp parallel for
     for (std::size_t i = 0; i < size_; i++) {
-      data_[i] = other.data_[i];
+      new (&(data_[i])) T(other.data_[i]);
     }
     return *this;
   }

--- a/src/core/diffusion/diffusion_grid.cc
+++ b/src/core/diffusion/diffusion_grid.cc
@@ -190,12 +190,12 @@ void DiffusionGrid::RunInitializers() {
           size_t idx = GetBoxIndex(box_coord);
           double value = initializers_[f](real_x, real_y, real_z);
           ChangeConcentrationBy(idx, value);
-          c1_.swap(c2_);
-          ChangeConcentrationBy(idx, value);
         }
       }
     }
   }
+  // Copy data to second array to ensure valid Dirichlet Boundary Conditions
+  c2_ = c1_;
 
   // Clear the initializer to free up space
   initializers_.clear();

--- a/src/core/diffusion/diffusion_grid.cc
+++ b/src/core/diffusion/diffusion_grid.cc
@@ -188,7 +188,10 @@ void DiffusionGrid::RunInitializers() {
           double real_z = grid_dimensions_[0] + z * box_length_;
           std::array<uint32_t, 3> box_coord = {x, y, z};
           size_t idx = GetBoxIndex(box_coord);
-          ChangeConcentrationBy(idx, initializers_[f](real_x, real_y, real_z));
+          double value = initializers_[f](real_x, real_y, real_z);
+          ChangeConcentrationBy(idx, value);
+          c1_.swap(c2_);
+          ChangeConcentrationBy(idx, value);
         }
       }
     }

--- a/src/core/diffusion/diffusion_grid.h
+++ b/src/core/diffusion/diffusion_grid.h
@@ -156,6 +156,7 @@ class DiffusionGrid {
   friend class RungaKuttaGrid;
   friend class EulerGrid;
   friend class StencilGrid;
+  friend class TestGrid;  // class used for testing (e.g. initialization)
 
   void ParametersCheck();
 

--- a/test/unit/core/container/parallel_resize_vector_test.cc
+++ b/test/unit/core/container/parallel_resize_vector_test.cc
@@ -102,4 +102,48 @@ TEST(ParallelResizeVector, AssignmentOperator) {
   }
 }
 
+TEST(ParallelResizeVector, AssignmentOperator2) {
+  ParallelResizeVector<int> v;
+  EXPECT_EQ(0u, v.size());
+  EXPECT_EQ(0u, v.capacity());
+
+  v.resize(17576, 123);
+
+  ParallelResizeVector<int> copy{};
+  copy = v;
+
+  EXPECT_EQ(17576u, copy.size());
+  EXPECT_EQ(17576u, copy.capacity());
+
+  for (auto el : copy) {
+    EXPECT_EQ(123, el);
+  }
+
+  v.clear();
+  v.resize(10, 124);
+  copy = v;
+
+  EXPECT_EQ(10u, copy.size());
+
+  for (auto el : copy) {
+    EXPECT_EQ(124, el);
+  }
+}
+
+TEST(ParallelResizeVector, AssignmentOperator_Self) {
+  ParallelResizeVector<int> v;
+  EXPECT_EQ(0u, v.size());
+  EXPECT_EQ(0u, v.capacity());
+
+  v.resize(17576, 123);
+  v = v;
+
+  EXPECT_EQ(17576u, v.size());
+  EXPECT_EQ(17576u, v.capacity());
+
+  for (auto el : v) {
+    EXPECT_EQ(123, el);
+  }
+}
+
 }  // namespace bdm

--- a/test/unit/core/diffusion_init_test.h
+++ b/test/unit/core/diffusion_init_test.h
@@ -1,0 +1,48 @@
+#ifndef UNIT_CORE_DIFFUSION_INIT_TEST_H_
+#define UNIT_CORE_DIFFUSION_INIT_TEST_H_
+
+#include "core/diffusion/diffusion_grid.h"
+
+namespace bdm {
+
+// Test class for diffusion grid to
+class TestGrid : public DiffusionGrid {
+ public:
+  TestGrid() {}
+  TestGrid(int substance_id, std::string substance_name, double dc, double mu,
+           int resolution = 11)
+      : DiffusionGrid(substance_id, substance_name, dc, mu, resolution) {}
+
+  void DiffuseWithClosedEdge() override { return; };
+
+  void DiffuseWithOpenEdge() override { return; };
+
+  void Swap() { c1_.swap(c2_); }
+
+  // Check if the entries of c1_ and c2_ are equal for each position.
+  bool CompareArrays() {
+    for (size_t i = 0; i < c1_.size(); i++) {
+      if (c1_[i] != c2_[i]) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  // Compares all values of the array c1_ with a specific value.
+  bool ComapareArrayWithValue(double value) {
+    for (size_t i = 0; i < c1_.size(); i++) {
+      if (c1_[i] != value) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+ private:
+  BDM_CLASS_DEF_OVERRIDE(TestGrid, 1);
+};
+
+}  // namespace bdm
+
+#endif  // UNIT_CORE_DIFFUSION_INIT_TEST_H_


### PR DESCRIPTION

![hybrid_snapshot_1](https://user-images.githubusercontent.com/44771875/128075698-b0e6f0ff-a990-410c-aaf3-5ec43c585ad9.png)
The Initialization of the diffusion grid only set the values of one of the two grids while the others remained zero. After the first iteration, we swap the arrays and artificially created zero boundaries resulting in very strange boundary effects. This PR fixes the initialization.
Image was obtained when running the diffusion `EulerGrid` with closed boudaries and inital condition `SetValues(){return 0.5;}`