### PR TITLE
Clang tidy performance update

### DIFF
--- a/src/core/analysis/time_series.cc
+++ b/src/core/analysis/time_series.cc
@@ -177,10 +177,11 @@ TimeSeries::TimeSeries() {}
 TimeSeries::TimeSeries(const TimeSeries& other) : data_(other.data_) {}
 
 // -----------------------------------------------------------------------------
-TimeSeries::TimeSeries(TimeSeries&& other) : data_(std::move(other.data_)) {}
+TimeSeries::TimeSeries(TimeSeries&& other) noexcept
+    : data_(std::move(other.data_)) {}
 
 // -----------------------------------------------------------------------------
-TimeSeries& TimeSeries::operator=(TimeSeries&& other) {
+TimeSeries& TimeSeries::operator=(TimeSeries&& other) noexcept {
   data_ = std::move(other.data_);
   return *this;
 }

--- a/src/core/analysis/time_series.h
+++ b/src/core/analysis/time_series.h
@@ -98,9 +98,9 @@ class TimeSeries {
 
   TimeSeries();
   TimeSeries(const TimeSeries& other);
-  TimeSeries(TimeSeries&& other);
+  TimeSeries(TimeSeries&& other) noexcept;
 
-  TimeSeries& operator=(TimeSeries&& other);
+  TimeSeries& operator=(TimeSeries&& other) noexcept;
   TimeSeries& operator=(const TimeSeries& other);
 
   /// Adds a new collector which is executed at each iteration.

--- a/src/core/behavior/chemotaxis.h
+++ b/src/core/behavior/chemotaxis.h
@@ -28,7 +28,7 @@ class Chemotaxis : public Behavior {
 
  public:
   Chemotaxis() {}
-  Chemotaxis(std::string substance, double speed)
+  Chemotaxis(const std::string& substance, double speed)
       : substance_(substance), speed_(speed) {
     dgrid_ = Simulation::GetActive()->GetResourceManager()->GetDiffusionGrid(
         substance);

--- a/src/core/behavior/gene_regulation.h
+++ b/src/core/behavior/gene_regulation.h
@@ -63,7 +63,7 @@ class GeneRegulation : public Behavior {
   ///              }
   ///
   /// \param initial_concentration
-  void AddGene(std::function<double(double, double)> first_derivative,
+  void AddGene(const std::function<double(double, double)>& first_derivative,
                double initial_concentration) {
     first_derivatives_.push_back(first_derivative);
     concentrations_.push_back(initial_concentration);

--- a/src/core/behavior/secretion.h
+++ b/src/core/behavior/secretion.h
@@ -30,7 +30,7 @@ class Secretion : public Behavior {
 
  public:
   Secretion() {}
-  explicit Secretion(std::string substance, double quantity = 1)
+  explicit Secretion(const std::string& substance, double quantity = 1)
       : substance_(substance), quantity_(quantity) {
     dgrid_ = Simulation::GetActive()->GetResourceManager()->GetDiffusionGrid(
         substance);

--- a/src/core/container/inline_vector.h
+++ b/src/core/container/inline_vector.h
@@ -283,7 +283,7 @@ class InlineVector {
     return *this;
   }
 
-  InlineVector<T, N>& operator=(InlineVector<T, N>&& other) {
+  InlineVector<T, N>& operator=(InlineVector<T, N>&& other) noexcept {
     if (this != &other) {
       data_ = std::move(other.data_);
       size_ = other.size_;

--- a/src/core/diffusion/diffusion_grid.h
+++ b/src/core/diffusion/diffusion_grid.h
@@ -18,6 +18,7 @@
 #include <array>
 #include <functional>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "core/container/math_array.h"
@@ -35,7 +36,7 @@ class DiffusionGrid {
   DiffusionGrid(int substance_id, std::string substance_name, double dc,
                 double mu, int resolution = 11)
       : substance_(substance_id),
-        substance_name_(substance_name),
+        substance_name_(std::move(substance_name)),
         dc_({{1 - dc, dc / 6, dc / 6, dc / 6, dc / 6, dc / 6, dc / 6}}),
         mu_(mu),
         resolution_(resolution) {}

--- a/src/core/diffusion/euler_grid.h
+++ b/src/core/diffusion/euler_grid.h
@@ -15,6 +15,8 @@
 #ifndef CORE_DIFFUSION_EULER_GRID_H_
 #define CORE_DIFFUSION_EULER_GRID_H_
 
+#include <utility>
+
 #include "core/diffusion/diffusion_grid.h"
 
 namespace bdm {
@@ -24,7 +26,8 @@ class EulerGrid : public DiffusionGrid {
   EulerGrid() {}
   EulerGrid(int substance_id, std::string substance_name, double dc, double mu,
             int resolution = 11)
-      : DiffusionGrid(substance_id, substance_name, dc, mu, resolution) {}
+      : DiffusionGrid(substance_id, std::move(substance_name), dc, mu,
+                      resolution) {}
 
   void DiffuseWithClosedEdge() override;
 

--- a/src/core/diffusion/runga_kutta_grid.h
+++ b/src/core/diffusion/runga_kutta_grid.h
@@ -15,6 +15,8 @@
 #ifndef CORE_DIFFUSION_RUNGA_KUTTA_GRID_H_
 #define CORE_DIFFUSION_RUNGA_KUTTA_GRID_H_
 
+#include <utility>
+
 #include "core/diffusion/diffusion_grid.h"
 #include "core/util/root.h"
 
@@ -25,7 +27,8 @@ class RungaKuttaGrid : public DiffusionGrid {
   RungaKuttaGrid() {}
   RungaKuttaGrid(int substance_id, std::string substance_name, double dc,
                  double mu, int resolution = 11)
-      : DiffusionGrid(substance_id, substance_name, dc, mu, resolution) {}
+      : DiffusionGrid(substance_id, std::move(substance_name), dc, mu,
+                      resolution) {}
 
   void Initialize() override {
     DiffusionGrid::Initialize();

--- a/src/core/diffusion/stencil_grid.h
+++ b/src/core/diffusion/stencil_grid.h
@@ -15,6 +15,8 @@
 #ifndef CORE_DIFFUSION_STENCIL_GRID_H_
 #define CORE_DIFFUSION_STENCIL_GRID_H_
 
+#include <utility>
+
 #include "core/diffusion/diffusion_grid.h"
 
 namespace bdm {
@@ -24,7 +26,8 @@ class StencilGrid : public DiffusionGrid {
   StencilGrid() {}
   StencilGrid(int substance_id, std::string substance_name, double dc,
               double mu, int resolution = 11)
-      : DiffusionGrid(substance_id, substance_name, dc, mu, resolution) {}
+      : DiffusionGrid(substance_id, std::move(substance_name), dc, mu,
+                      resolution) {}
 
   void DiffuseWithClosedEdge() override;
 

--- a/src/core/memory/memory_manager.cc
+++ b/src/core/memory/memory_manager.cc
@@ -305,7 +305,7 @@ PoolAllocator::PoolAllocator(std::size_t size, uint64_t size_n_pages,
   }
 }
 
-PoolAllocator::PoolAllocator(PoolAllocator&& other)
+PoolAllocator::PoolAllocator(PoolAllocator&& other) noexcept
     : size_(other.size_),
       tinfo_(other.tinfo_),
       numa_allocators_(std::move(other.numa_allocators_)) {}

--- a/src/core/memory/memory_manager.h
+++ b/src/core/memory/memory_manager.h
@@ -130,7 +130,7 @@ class PoolAllocator {
   PoolAllocator(std::size_t size, uint64_t size_n_pages, double growth_rate,
                 uint64_t max_mem_per_thread_factor);
 
-  PoolAllocator(PoolAllocator&& other);
+  PoolAllocator(PoolAllocator&& other) noexcept;
   PoolAllocator(const PoolAllocator& other) = delete;
 
   ~PoolAllocator();

--- a/src/core/model_initializer.cc
+++ b/src/core/model_initializer.cc
@@ -21,7 +21,7 @@
 namespace bdm {
 
 void ModelInitializer::DefineSubstance(size_t substance_id,
-                                       std::string substance_name,
+                                       const std::string& substance_name,
                                        double diffusion_coeff,
                                        double decay_constant, int resolution) {
   auto* sim = Simulation::GetActive();

--- a/src/core/model_initializer.h
+++ b/src/core/model_initializer.h
@@ -327,7 +327,8 @@ struct ModelInitializer {
   /// @param[in]  decay_constant   The decay constant
   /// @param[in]  resolution       The resolution of the diffusion grid
   ///
-  static void DefineSubstance(size_t substance_id, std::string substance_name,
+  static void DefineSubstance(size_t substance_id,
+                              const std::string& substance_name,
                               double diffusion_coeff, double decay_constant,
                               int resolution = 10);
 

--- a/src/core/operation/op_timer.h
+++ b/src/core/operation/op_timer.h
@@ -16,6 +16,7 @@
 #define CORE_OPERATION_OP_TIMER_H_
 
 #include <string>
+#include <utility>
 #include "core/simulation.h"
 #include "core/util/timing.h"
 
@@ -25,9 +26,9 @@ namespace bdm {
 template <typename TOp>
 class OpTimer {
  public:
-  explicit OpTimer(std::string timer_msg) : timer_msg_(timer_msg) {}
+  explicit OpTimer(std::string timer_msg) : timer_msg_(std::move(timer_msg)) {}
   explicit OpTimer(std::string timer_msg, const TOp& op)
-      : timer_msg_(timer_msg), operation_(op) {}
+      : timer_msg_(std::move(timer_msg)), operation_(op) {}
 
   template <typename Container>
   void operator()(Container* cells, uint16_t numa_node, uint16_t type_idx) {

--- a/src/core/param/command_line_options.cc
+++ b/src/core/param/command_line_options.cc
@@ -112,7 +112,7 @@ void CommandLineOptions::AddCoreOptions() {
 
 void CommandLineOptions::ExtractSimulationName(const char* path) {
   string s(path);
-  auto pos = s.find_last_of("/");
+  auto pos = s.find_last_of('/');
   if (pos == std::string::npos) {
     sim_name_ = s;
   } else {

--- a/src/core/param/command_line_options.h
+++ b/src/core/param/command_line_options.h
@@ -26,6 +26,7 @@
 #include <iostream>
 #include <ostream>
 #include <string>
+#include <utility>
 
 #include "bdm_version.h"
 #include "core/simulation.h"
@@ -44,16 +45,18 @@ class CommandLineOptions {
 
   /// Add an extra command line option
   template <typename T>
-  void AddOption(std::string opt, std::string def, std::string description = "",
+  void AddOption(const std::string& opt, std::string def,
+                 const std::string& description = "",
                  std::string group = "Simulation") {
-    AddOption(group)(opt, description, cxxopts::value<T>()->default_value(def));
+    AddOption(std::move(group))(opt, description,
+                                cxxopts::value<T>()->default_value(def));
   }
 
   /// Return the simulation name that was parsed from argv[0]
   std::string GetSimulationName();
 
   template <typename T>
-  T Get(std::string val) {
+  T Get(const std::string& val) {
     if (parser_ == nullptr) {
       this->Parse();
     }

--- a/src/core/resource_manager.h
+++ b/src/core/resource_manager.h
@@ -57,7 +57,7 @@ class ResourceManager {
 
   virtual ~ResourceManager();
 
-  ResourceManager& operator=(ResourceManager&& other) {
+  ResourceManager& operator=(ResourceManager&& other) noexcept {
     if (agents_.size() != other.agents_.size()) {
       Log::Fatal(
           "Restored ResourceManager has different number of NUMA nodes.");
@@ -153,7 +153,7 @@ class ResourceManager {
   /// Return the diffusion grid which holds the substance of specified name
   /// Caution: using this function in a tight loop will result in a slow
   /// simulation. Use `GetDiffusionGrid(size_t)` in those cases.
-  DiffusionGrid* GetDiffusionGrid(std::string substance_name) const {
+  DiffusionGrid* GetDiffusionGrid(const std::string& substance_name) const {
     for (auto& el : diffusion_grids_) {
       auto& dg = el.second;
       if (dg->GetSubstanceName() == substance_name) {

--- a/src/core/util/jit.cc
+++ b/src/core/util/jit.cc
@@ -106,8 +106,8 @@ std::vector<TDataMember*> FindDataMemberSlow(TClass* tclass,
 
 // -----------------------------------------------------------------------------
 JitForEachDataMemberFunctor::JitForEachDataMemberFunctor(
-    TClass* tclass, const std::vector<std::string> dm_names,
-    const std::string functor_name,
+    TClass* tclass, const std::vector<std::string>& dm_names,
+    const std::string& functor_name,
     const std::function<std::string(
         const std::string&, const std::vector<TDataMember*>&)>& code_generator)
     : functor_name_(Concat(functor_name, counter_++)),

--- a/src/core/util/jit.h
+++ b/src/core/util/jit.h
@@ -49,8 +49,8 @@ std::vector<TDataMember*> FindDataMemberSlow(TClass* tclass,
 class JitForEachDataMemberFunctor {
  public:
   JitForEachDataMemberFunctor(
-      TClass* tclass, const std::vector<std::string> dm_names,
-      const std::string functor_name,
+      TClass* tclass, const std::vector<std::string>& dm_names,
+      const std::string& functor_name,
       const std::function<std::string(const std::string&,
                                       const std::vector<TDataMember*>&)>&
           code_generation);

--- a/src/core/util/plot_memory_layout.cc
+++ b/src/core/util/plot_memory_layout.cc
@@ -39,7 +39,7 @@
 namespace bdm {
 
 // -----------------------------------------------------------------------------
-void PlotMemoryLayout(const std::vector<Agent*> agents, int numa_node) {
+void PlotMemoryLayout(const std::vector<Agent*>& agents, int numa_node) {
   TCanvas c;
   c.SetCanvasSize(1920, 1200);
   std::vector<double> x(agents.size());
@@ -71,7 +71,7 @@ void PlotMemoryLayout(const std::vector<Agent*> agents, int numa_node) {
 }
 
 // -----------------------------------------------------------------------------
-void PlotMemoryHistogram(const std::vector<Agent*> agents, int numa_node) {
+void PlotMemoryHistogram(const std::vector<Agent*>& agents, int numa_node) {
   TCanvas c;
   c.SetCanvasSize(1920, 1200);
 

--- a/src/core/util/plot_memory_layout.h
+++ b/src/core/util/plot_memory_layout.h
@@ -22,10 +22,10 @@ namespace bdm {
 class Agent;
 
 // -----------------------------------------------------------------------------
-void PlotMemoryLayout(const std::vector<Agent*> agents, int numa_node);
+void PlotMemoryLayout(const std::vector<Agent*>& agents, int numa_node);
 
 // -----------------------------------------------------------------------------
-void PlotMemoryHistogram(const std::vector<Agent*> agents, int numa_node);
+void PlotMemoryHistogram(const std::vector<Agent*>& agents, int numa_node);
 
 // -----------------------------------------------------------------------------
 void PlotNeighborMemoryHistogram(bool before = false);

--- a/src/core/util/timing_aggregator.h
+++ b/src/core/util/timing_aggregator.h
@@ -42,7 +42,9 @@ class TimingAggregator {
     }
   }
 
-  void AddDescription(const std::string text) { descriptions_.push_back(text); }
+  void AddDescription(const std::string& text) {
+    descriptions_.push_back(text);
+  }
 
  private:
   std::map<std::string, std::vector<int64_t>> timings_;

--- a/src/core/util/vtune_helper.h
+++ b/src/core/util/vtune_helper.h
@@ -31,18 +31,14 @@ namespace bdm {
 /// with "my_task_name"
 class VTuneTask {
  public:
-  explicit VTuneTask(std::string task_name) {
+  explicit VTuneTask(const std::string& task_name) {
     domain_ = __itt_domain_create("BDMTraces.MyDomain");
     task_ = __itt_string_handle_create(task_name.c_str());
   }
 
-  void Start() {
-    __itt_task_begin(domain_, __itt_null, __itt_null, task_);
-  }
+  void Start() { __itt_task_begin(domain_, __itt_null, __itt_null, task_); }
 
-  void Stop() {
-    __itt_task_end(domain_);
-  }
+  void Stop() { __itt_task_end(domain_); }
 
  private:
   __itt_domain* domain_;

--- a/src/core/visualization/root/notebook_util.h
+++ b/src/core/visualization/root/notebook_util.h
@@ -15,6 +15,7 @@
 #define CORE_VISUALIZATION_ROOT_NOTEBOOK_UTIL_H_
 
 #include <string>
+#include <utility>
 
 #include "core/simulation.h"
 #include "core/visualization/root/adaptor.h"
@@ -29,7 +30,8 @@ inline void VisualizeInNotebook(size_t w = 300, size_t h = 300,
   // Force an update of the visualization engine
   sim->GetScheduler()->GetRootVisualization()->Visualize(
       param->visualization_interval);
-  sim->GetScheduler()->GetRootVisualization()->DrawInCanvas(w, h, opt);
+  sim->GetScheduler()->GetRootVisualization()->DrawInCanvas(w, h,
+                                                            std::move(opt));
 }
 
 }  // namespace bdm

--- a/src/core/visualization/visualization_adaptor.cc
+++ b/src/core/visualization/visualization_adaptor.cc
@@ -32,7 +32,7 @@ namespace bdm {
 // library more than once
 static std::unordered_map<std::string, TPluginHandler *> loaded_;
 
-VisualizationAdaptor *VisualizationAdaptor::Create(std::string adaptor) {
+VisualizationAdaptor *VisualizationAdaptor::Create(const std::string &adaptor) {
   auto *param = Simulation::GetActive()->GetParam();
   if (!(param->insitu_visualization || param->export_visualization)) {
     return nullptr;

--- a/src/core/visualization/visualization_adaptor.h
+++ b/src/core/visualization/visualization_adaptor.h
@@ -23,7 +23,7 @@ class VisualizationAdaptor {
  public:
   VisualizationAdaptor() {}
 
-  static VisualizationAdaptor* Create(std::string adaptor);
+  static VisualizationAdaptor* Create(const std::string& adaptor);
 
   virtual ~VisualizationAdaptor() {}
 


### PR DESCRIPTION
Clang tidy suggest some modification to enhance performance. I separated different suggestions into different commits.
I'm quite confident that the `pass-by-reference`, `std::move` and `fast sting find` are helpful. @LukasBreitwieser at some places, clang tidy suggested `noexcept` and at some other places it complained about the `reinterpret_cast`. The latter is related to [this](https://clang.llvm.org/extra/clang-tidy/checks/performance-no-int-to-ptr.html) clang-tidy flag. Would you mind double-checking?