### PR TITLE
Avoid overriding results

### DIFF
--- a/src/core/param/param.h
+++ b/src/core/param/param.h
@@ -129,10 +129,14 @@ struct Param {
   ///     unibn_bucketsize = 16
   uint32_t unibn_bucketsize = 16;
 
-  /// If set to true, BioDynaMo will automatically delete all contents
+  /// If set to true (default), BioDynaMo will automatically delete all contents
   /// inside `Param::output_dir` at the beginning of the simulation.
-  /// Use with caution, especially in combination with `Param::output_dir`
-  bool remove_output_dir_contents = false;
+  /// Use with caution in combination with `Param::output_dir`. If you do not
+  /// want to delete the content, set this parameter to false. BioDynaMo then
+  /// organizes your simulation outputs in additional subfolders labelled with
+  /// the date-time of your simulation `YYYY-MM-DD-HH:MM:SS`. Note that you will
+  /// inevitably use more disk space with this option.
+  bool remove_output_dir_contents = true;
 
   /// Backup file name for full simulation backups\n
   /// Path is relative to working directory.\n

--- a/src/core/simulation.cc
+++ b/src/core/simulation.cc
@@ -547,17 +547,17 @@ void Simulation::InitializeOutputDir() {
     output_dir_ = param_->output_dir;
   } else {
     output_dir_ = Concat(param_->output_dir, "/", unique_name_);
-    // If we do not remove the output directory, we add a timestamp to the
-    // output directory to avoid overriding previous results.
-    if (!param_->remove_output_dir_contents) {
-      time_t rawtime;
-      struct tm* timeinfo;
-      char buffer[80];
-      time(&rawtime);
-      timeinfo = localtime(&rawtime);
-      strftime(buffer, sizeof(buffer), "/%Y-%m-%d-%H:%M:%S", timeinfo);
-      output_dir_ += buffer;
-    }
+  }
+  // If we do not remove the output directory, we add a timestamp to the
+  // output directory to avoid overriding previous results.
+  if (!param_->remove_output_dir_contents) {
+    time_t rawtime;
+    struct tm* timeinfo;
+    char buffer[80];
+    time(&rawtime);
+    timeinfo = localtime(&rawtime);
+    strftime(buffer, sizeof(buffer), "/%Y-%m-%d-%H:%M:%S", timeinfo);
+    output_dir_ += buffer;
   }
 
   if (system(Concat("mkdir -p ", output_dir_).c_str())) {

--- a/src/core/simulation.cc
+++ b/src/core/simulation.cc
@@ -543,6 +543,17 @@ void Simulation::InitializeUniqueName(const std::string& simulation_name) {
 }
 
 void Simulation::InitializeOutputDir() {
+  // If we do not remove the output directory, we add a timestamp to the output
+  // directory to avoid overriding previous results.
+  if (!param_->remove_output_dir_contents) {
+    time_t rawtime;
+    struct tm* timeinfo;
+    char buffer[80];
+    time(&rawtime);
+    timeinfo = localtime(&rawtime);
+    strftime(buffer, sizeof(buffer), "/%Y-%m-%d-%H:%M:%S", timeinfo);
+    unique_name_ += buffer;
+  }
   if (unique_name_ == "") {
     output_dir_ = param_->output_dir;
   } else {
@@ -556,13 +567,13 @@ void Simulation::InitializeOutputDir() {
     if (param_->remove_output_dir_contents) {
       RemoveDirectoryContents(output_dir_);
     } else {
-      Log::Warning(
+      // We throw a fatal because it will override previous results from a
+      // possibly expensive simulation. This should not happen unintentionally.
+      Log::Fatal(
           "Simulation::InitializeOutputDir", "Output dir (", output_dir_,
-          ") is not empty. Files will be overriden. This could cause "
-          "inconsistent state of (e.g. visualization files). Consider removing "
-          "all contents "
-          "prior to running a simulation. Have a look at "
-          "Param::remove_output_dir_contents to remove files automatically.");
+          ") is not empty. Previous result files would be overriden. Abort."
+          "Please set Param::remove_output_dir_contents to true to remove files"
+          " automatically or clear the output directory by hand.");
     }
   }
 }

--- a/src/core/simulation.cc
+++ b/src/core/simulation.cc
@@ -543,22 +543,23 @@ void Simulation::InitializeUniqueName(const std::string& simulation_name) {
 }
 
 void Simulation::InitializeOutputDir() {
-  // If we do not remove the output directory, we add a timestamp to the output
-  // directory to avoid overriding previous results.
-  if (!param_->remove_output_dir_contents) {
-    time_t rawtime;
-    struct tm* timeinfo;
-    char buffer[80];
-    time(&rawtime);
-    timeinfo = localtime(&rawtime);
-    strftime(buffer, sizeof(buffer), "/%Y-%m-%d-%H:%M:%S", timeinfo);
-    unique_name_ += buffer;
-  }
   if (unique_name_ == "") {
     output_dir_ = param_->output_dir;
   } else {
     output_dir_ = Concat(param_->output_dir, "/", unique_name_);
+    // If we do not remove the output directory, we add a timestamp to the
+    // output directory to avoid overriding previous results.
+    if (!param_->remove_output_dir_contents) {
+      time_t rawtime;
+      struct tm* timeinfo;
+      char buffer[80];
+      time(&rawtime);
+      timeinfo = localtime(&rawtime);
+      strftime(buffer, sizeof(buffer), "/%Y-%m-%d-%H:%M:%S", timeinfo);
+      output_dir_ += buffer;
+    }
   }
+
   if (system(Concat("mkdir -p ", output_dir_).c_str())) {
     Log::Fatal("Simulation::InitializeOutputDir",
                "Failed to make output directory ", output_dir_);

--- a/test/unit/core/simulation_test.cc
+++ b/test/unit/core/simulation_test.cc
@@ -390,11 +390,8 @@ TEST_F(SimulationTest, MultipleJsonConfigsAndPrecedence) {
 #endif  // USE_DICT
 
 TEST_F(SimulationTest, SimulationId_OutputDir) {
-  auto SetParam = [](Param* param) {
-    param->remove_output_dir_contents = true;
-  };
-  Simulation simulation("my-simulation", SetParam);
-  Simulation simulation1("my-simulation", SetParam);
+  Simulation simulation("my-simulation");
+  Simulation simulation1("my-simulation");
 
   EXPECT_EQ("my-simulation", simulation.GetUniqueName());
   EXPECT_EQ("output/my-simulation", simulation.GetOutputDir());
@@ -432,10 +429,7 @@ TEST_F(SimulationTest, SimulationId_OutputDir_TimeStamp) {
 }
 
 TEST_F(SimulationTest, SimulationId_OutputDir_NoSimName) {
-  auto SetParam = [](Param* param) {
-    param->remove_output_dir_contents = true;
-  };
-  Simulation simulation("", SetParam);
+  Simulation simulation("");
 
   EXPECT_EQ("", simulation.GetUniqueName());
   EXPECT_EQ("output", simulation.GetOutputDir());
@@ -468,7 +462,10 @@ TEST_F(SimulationTest, DontRemoveOutputDirContents) {
   fs::create_directory(Concat("output/", TEST_NAME, "/subdir"));
   EXPECT_FALSE(fs::is_empty(Concat("output/", TEST_NAME)));
 
-  Simulation sim(TEST_NAME);
+  auto SetParam = [](Param* param) {
+    param->remove_output_dir_contents = false;
+  };
+  Simulation sim(TEST_NAME, SetParam);
   EXPECT_FALSE(fs::is_empty(Concat("output/", TEST_NAME)));
 }
 

--- a/test/unit/core/simulation_test.cc
+++ b/test/unit/core/simulation_test.cc
@@ -16,6 +16,8 @@
 #include <omp.h>
 #include <experimental/filesystem>
 #include <fstream>
+#include <regex>
+#include <string>
 #include <type_traits>
 
 #include "core/agent/cell.h"
@@ -388,8 +390,11 @@ TEST_F(SimulationTest, MultipleJsonConfigsAndPrecedence) {
 #endif  // USE_DICT
 
 TEST_F(SimulationTest, SimulationId_OutputDir) {
-  Simulation simulation("my-simulation");
-  Simulation simulation1("my-simulation");
+  auto SetParam = [](Param* param) {
+    param->remove_output_dir_contents = true;
+  };
+  Simulation simulation("my-simulation", SetParam);
+  Simulation simulation1("my-simulation", SetParam);
 
   EXPECT_EQ("my-simulation", simulation.GetUniqueName());
   EXPECT_EQ("output/my-simulation", simulation.GetOutputDir());
@@ -398,11 +403,56 @@ TEST_F(SimulationTest, SimulationId_OutputDir) {
   EXPECT_EQ("output/my-simulation1", simulation1.GetOutputDir());
 }
 
-TEST_F(SimulationTest, SimulationId_OutputDir2) {
-  Simulation simulation("");
+TEST_F(SimulationTest, SimulationId_OutputDir_TimeStamp) {
+  auto SetParam = [](Param* param) {
+    param->remove_output_dir_contents = false;
+  };
+  Simulation simulation("my-simulation", SetParam);
+  Simulation simulation1("my-simulation", SetParam);
+
+  // The regex below, is supposed to catch the following example structure
+  // output[D+]/my-simulation[D+]/2021[d{4}]-08[d{2}]-09[d{2}]-
+  // 12[d{2}]:24[d{2}]:51[d{2}]
+  // For timestamp2, we add an additional [d] after the second [D+] to capture
+  // my-simulation1 [D+d].
+  std::regex timestamp1{
+      "\\D+\\/\\D+\\/\\d{4}-\\d{2}-\\d{2}-\\d{2}:\\d{2}:\\d{2}"};
+  std::regex timestamp2{
+      "\\D+\\/\\D+\\d\\/\\d{4}-\\d{2}-\\d{2}-\\d{2}:\\d{2}:\\d{2}"};
+
+  std::string out1 = simulation.GetOutputDir();
+  std::string out2 = simulation1.GetOutputDir();
+
+  EXPECT_EQ("my-simulation", simulation.GetUniqueName());
+  EXPECT_TRUE(regex_match(out1, timestamp1));
+  // EXPECT_TRUE( )
+
+  EXPECT_EQ("my-simulation1", simulation1.GetUniqueName());
+  EXPECT_TRUE(regex_match(out2, timestamp2));
+}
+
+TEST_F(SimulationTest, SimulationId_OutputDir_NoSimName) {
+  auto SetParam = [](Param* param) {
+    param->remove_output_dir_contents = true;
+  };
+  Simulation simulation("", SetParam);
 
   EXPECT_EQ("", simulation.GetUniqueName());
   EXPECT_EQ("output", simulation.GetOutputDir());
+}
+
+TEST_F(SimulationTest, SimulationId_OutputDir_NoSimName_TimeStamp) {
+  auto SetParam = [](Param* param) {
+    param->remove_output_dir_contents = false;
+  };
+  Simulation simulation("", SetParam);
+
+  // The regex below, is supposed to catch the following example structure
+  // output[D+]/2021[d{4}]-08[d{2}]-09[d{2}]-12[d{2}]:24[d{2}]:51[d{2}]
+  std::regex timestamp{"\\D+\\/\\d{4}-\\d{2}-\\d{2}-\\d{2}:\\d{2}:\\d{2}"};
+
+  EXPECT_EQ("", simulation.GetUniqueName());
+  EXPECT_TRUE(regex_match(simulation.GetOutputDir(), timestamp));
 }
 
 TEST_F(SimulationTest, InlineConfig) {

--- a/test/unit/core/visualization/paraview/adaptor_test.cc
+++ b/test/unit/core/visualization/paraview/adaptor_test.cc
@@ -36,8 +36,6 @@ class ParaviewAdaptorTest : public ::testing::Test {
   static constexpr char const* kSimulationName = "MySimulation";
   static constexpr char const* kSimulationInfoJson =
       "output/MySimulation/simulation_info.json";
-  static constexpr char const* kSimulationInfoJsonFileName =
-      "simulation_info.json";
   static constexpr char const* kParaviewState =
       "output/MySimulation/MySimulation.pvsm";
 
@@ -163,7 +161,7 @@ TEST_F(ParaviewAdaptorTest, GenerateParaviewState) {
 
   std::ofstream ofs;
   std::string json_fn =
-      Concat(simulation.GetOutputDir(), "/", kSimulationInfoJsonFileName);
+      Concat(simulation.GetOutputDir(), "/simulation_info.json");
   ofs.open(json_fn);
   ofs << empty_json;
   ofs.close();

--- a/test/unit/core/visualization/paraview/adaptor_test.cc
+++ b/test/unit/core/visualization/paraview/adaptor_test.cc
@@ -55,7 +55,6 @@ class ParaviewAdaptorTest : public ::testing::Test {
 TEST_F(ParaviewAdaptorTest, GenerateSimulationInfoJson) {
   auto set_param = [](auto* param) {
     // set-up Param values
-    param->remove_output_dir_contents = true;
     param->export_visualization = true;
     param->visualize_agents.clear();
     param->visualize_agents["Cell"] = {};

--- a/test/unit/core/visualization/paraview/adaptor_test.cc
+++ b/test/unit/core/visualization/paraview/adaptor_test.cc
@@ -36,6 +36,8 @@ class ParaviewAdaptorTest : public ::testing::Test {
   static constexpr char const* kSimulationName = "MySimulation";
   static constexpr char const* kSimulationInfoJson =
       "output/MySimulation/simulation_info.json";
+  static constexpr char const* kSimulationInfoJsonFileName =
+      "simulation_info.json";
   static constexpr char const* kParaviewState =
       "output/MySimulation/MySimulation.pvsm";
 
@@ -160,7 +162,9 @@ TEST_F(ParaviewAdaptorTest, GenerateParaviewState) {
 )STR";
 
   std::ofstream ofs;
-  ofs.open(kSimulationInfoJson);
+  std::string json_fn =
+      Concat(simulation.GetOutputDir(), "/", kSimulationInfoJsonFileName);
+  ofs.open(json_fn);
   ofs << empty_json;
   ofs.close();
 

--- a/test/unit/core/visualization/paraview/adaptor_test.cc
+++ b/test/unit/core/visualization/paraview/adaptor_test.cc
@@ -55,6 +55,7 @@ class ParaviewAdaptorTest : public ::testing::Test {
 TEST_F(ParaviewAdaptorTest, GenerateSimulationInfoJson) {
   auto set_param = [](auto* param) {
     // set-up Param values
+    param->remove_output_dir_contents = true;
     param->export_visualization = true;
     param->visualize_agents.clear();
     param->visualize_agents["Cell"] = {};


### PR DESCRIPTION
Currently, BioDynaMo overrides previous results even if `remove_output_dir_contents` is set to `false`. This is problematic since the simulations can be computationally expensive and you don't want to override them by default. With this PR, we introduce subfolders to the existing output folder structure or the type "YYYY-MM-DD-HH:MM:SS".

For instance, running the `soma_clustering` demo five times results in the following folder structure:
```
~/Programming/biodynamo_projects/soma_clustering on  master! ⌚ 15:21:50
$ tree output 
output
└── soma_clustering
    ├── 2021-08-10-15:21:43
    ├── 2021-08-10-15:21:45
    ├── 2021-08-10-15:21:46
    ├── 2021-08-10-15:21:48
    └── 2021-08-10-15:21:49

6 directories, 0 files
```
I also added tests verifying this.