### PR TITLE
Fix compiler warning for self assignment

### DIFF
--- a/test/unit/core/container/parallel_resize_vector_test.cc
+++ b/test/unit/core/container/parallel_resize_vector_test.cc
@@ -136,7 +136,7 @@ TEST(ParallelResizeVector, AssignmentOperator_Self) {
   EXPECT_EQ(0u, v.capacity());
 
   v.resize(17576, 123);
-  v = v;
+  v = static_cast<ParallelResizeVector<int>&>(v);
 
   EXPECT_EQ(17576u, v.size());
   EXPECT_EQ(17576u, v.capacity());


### PR DESCRIPTION
Fix for:
```
[427/476] Building CXX object CMakeFiles/biodynamo-unit-tests.dir/test/unit/core/container/parallel_resize_vector_test.cc.o
../test/unit/core/container/parallel_resize_vector_test.cc:139:5: warning: explicitly assigning value of variable of type 'ParallelResizeVector<int>' to itself [-Wself-assign-overloaded]
  v = v;
  ~ ^ ~
1 warning generated.
```

See this discussion https://reviews.llvm.org/D45766#1097736