### PR TITLE
Disable ForEachAgentParallelFilter on M1 (clang13)

### DIFF
--- a/test/unit/core/resource_manager_test.cc
+++ b/test/unit/core/resource_manager_test.cc
@@ -78,6 +78,12 @@ TEST(ResourceManagerTest, ForEachAgentFilter) {
   EXPECT_EQ(2u, counter);
 }
 
+// This test currently produces a segmentation fault with clang 13 on macOS 11.6
+// during the build and is therefore disabled for the specific combination of
+// OS, architecture, and compiler version. Submitted bug to Apple on 2021-09-22.
+// The issue arises with the `#pragma omp critical` statement.
+// Todo(tobias): revisit this bug asap.
+#if !(defined(__APPLE__) && defined(__arm64__) && __clang_major__ == 13)
 TEST(ResourceManagerTest, ForEachAgentParallelFilter) {
   Simulation simulation(TEST_NAME);
   auto* rm = simulation.GetResourceManager();
@@ -133,6 +139,7 @@ TEST(ResourceManagerTest, ForEachAgentParallelFilter) {
     EXPECT_TRUE(a->GetData() % 2 == 1);
   }
 }
+#endif  // APPLE ARM64 CLANG==13
 
 TEST(ResourceManagerTest, GetNumAgents) { RunGetNumAgents(); }
 


### PR DESCRIPTION
The test `ForEachAgentParallelFilter` in `resource_manager_test.cc` produces the following error on the m1 with latest apple version (Xcode 13, clang 13, macOS 11.6).

```
[ 94%] Building CXX object CMakeFiles/biodynamo-unit-tests.dir/test/unit/core/resource_manager_test.cc.o
clang: error: unable to execute command: Segmentation fault: 11
clang: error: clang frontend command failed due to signal (use -v to see invocation)
Apple clang version 13.0.0 (clang-1300.0.29.3)
Target: arm64-apple-darwin20.6.0
Thread model: posix
InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin
clang: note: diagnostic msg: 
********************

PLEASE ATTACH THE FOLLOWING FILES TO THE BUG REPORT:
Preprocessed source(s) and associated run script(s) are located at:
clang: note: diagnostic msg: /var/folders/y4/brc2x33924lg1jf41sdd8vdr0000gn/T/resource_manager_test-d214a0.cpp
clang: note: diagnostic msg: /var/folders/y4/brc2x33924lg1jf41sdd8vdr0000gn/T/resource_manager_test-d214a0.sh
clang: note: diagnostic msg: Crash backtrace is located in
clang: note: diagnostic msg: /Users/tobias/Library/Logs/DiagnosticReports/clang_<YYYY-MM-DD-HHMMSS>_<hostname>.crash
clang: note: diagnostic msg: (choose the .crash file that corresponds to your crash)
clang: note: diagnostic msg: 

********************
make[2]: *** [CMakeFiles/biodynamo-unit-tests.dir/test/unit/core/resource_manager_test.cc.o] Error 254
make[2]: *** Waiting for unfinished jobs....
make[1]: *** [CMakeFiles/biodynamo-unit-tests.dir/all] Error 2
make: *** [all] Error 2
```

I, therefore, deactivated the test on the specific combination of architecture, OS, and compiler version.