### PR TITLE
WIP: Avoid deadlock in `ChangeConcentrationBy`

### DIFF
--- a/src/core/diffusion/diffusion_grid.h
+++ b/src/core/diffusion/diffusion_grid.h
@@ -89,9 +89,13 @@ class DiffusionGrid {
 
   void SetDecayConstant(double mu) { mu_ = mu; }
 
-  void SetConcentrationThreshold(double t) { concentration_threshold_ = t; }
+  void SetMaxConcentration(double t) { max_concentration_ = t; }
 
-  double GetConcentrationThreshold() const { return concentration_threshold_; }
+  double GetMaxConcentration() const { return max_concentration_; }
+
+  void SetMinConcentration(double t) { min_concentration_ = t; }
+
+  double GetMinConcentration() const { return min_concentration_; }
 
   const double* GetAllConcentrations() const { return c1_.data(); }
 
@@ -177,6 +181,10 @@ class DiffusionGrid {
                    const ParallelResizeVector<Double3>& old_gradients,
                    size_t old_resolution);
 
+  /// Cuts off values of the grid at the max_concentration_ and
+  /// min_concentration_.
+  void ApplyThreshold();
+
   /// The id of the substance of this grid
   int substance_ = 0;
   /// The name of the substance of this grid
@@ -195,7 +203,9 @@ class DiffusionGrid {
   /// The array of gradients (x, y, z)
   ParallelResizeVector<Double3> gradients_ = {};
   /// The maximum concentration value that a box can have
-  double concentration_threshold_ = 1e15;
+  double max_concentration_ = 1e15;
+  /// The minimum concentration value that a box can have
+  double min_concentration_ = -1e15;
   /// The diffusion coefficients [cc, cw, ce, cs, cn, cb, ct]
   std::array<double, 7> dc_ = {{0}};
   /// The timestep resolution fhe diffusion grid

--- a/test/unit/core/diffusion_test.cc
+++ b/test/unit/core/diffusion_test.cc
@@ -167,7 +167,8 @@ TEST(DiffusionTest, LeakingEdge) {
   DiffusionGrid* d_grid = new StencilGrid(0, "Kalium", 0.4, 0, 5);
 
   d_grid->Initialize();
-  d_grid->SetConcentrationThreshold(1e15);
+  d_grid->SetMaxConcentration(1e15);
+  d_grid->SetMinConcentration(-1e15);
 
   for (int i = 0; i < 100; i++) {
     d_grid->ChangeConcentrationBy({{0, 0, 0}}, 4);
@@ -235,7 +236,8 @@ TEST(DiffusionTest, ClosedEdge) {
   DiffusionGrid* d_grid = new StencilGrid(0, "Kalium", 0.4, 0, 5);
 
   d_grid->Initialize();
-  d_grid->SetConcentrationThreshold(1e15);
+  d_grid->SetMaxConcentration(1e15);
+  d_grid->SetMinConcentration(-1e15);
 
   for (int i = 0; i < 100; i++) {
     d_grid->ChangeConcentrationBy({{0, 0, 0}}, 4);
@@ -304,7 +306,8 @@ TEST(DiffusionTest, CopyOldData) {
   DiffusionGrid* d_grid = new StencilGrid(0, "Kalium", 0.4, 0, 5);
 
   d_grid->Initialize();
-  d_grid->SetConcentrationThreshold(1e15);
+  d_grid->SetMaxConcentration(1e15);
+  d_grid->SetMinConcentration(-1e15);
 
   for (int i = 0; i < 100; i++) {
     d_grid->ChangeConcentrationBy({{0, 0, 0}}, 4);
@@ -383,7 +386,8 @@ TEST(DiffusionTest, IOTest) {
 
   // Create a 100x100x100 diffusion grid with 20 boxes per dimension
   d_grid->Initialize();
-  d_grid->SetConcentrationThreshold(42);
+  d_grid->SetMaxConcentration(42);
+  d_grid->SetMinConcentration(-42);
   d_grid->SetDecayConstant(0.01);
 
   // write to root file
@@ -397,7 +401,8 @@ TEST(DiffusionTest, IOTest) {
 
   EXPECT_EQ("Kalium", restored_d_grid->GetSubstanceName());
   EXPECT_EQ(10, restored_d_grid->GetBoxLength());
-  EXPECT_EQ(42, restored_d_grid->GetConcentrationThreshold());
+  EXPECT_EQ(42, restored_d_grid->GetMaxConcentration());
+  EXPECT_EQ(-42, restored_d_grid->GetMinConcentration());
   EXPECT_NEAR(0.4, restored_d_grid->GetDiffusionCoefficients()[0], eps);
   EXPECT_NEAR(0.1, restored_d_grid->GetDiffusionCoefficients()[1], eps);
   EXPECT_NEAR(0.1, restored_d_grid->GetDiffusionCoefficients()[2], eps);
@@ -480,9 +485,12 @@ TEST(DiffusionTest, EulerConvergence) {
   d_grid4->Initialize();
   d_grid8->Initialize();
 
-  d_grid2->SetConcentrationThreshold(1e15);
-  d_grid4->SetConcentrationThreshold(1e15);
-  d_grid8->SetConcentrationThreshold(1e15);
+  d_grid2->SetMaxConcentration(1e15);
+  d_grid2->SetMinConcentration(-1e15);
+  d_grid4->SetMaxConcentration(1e15);
+  d_grid4->SetMinConcentration(-1e15);
+  d_grid8->SetMaxConcentration(1e15);
+  d_grid8->SetMinConcentration(-1e15);
 
   // instantaneous point source
   int init = 1e5;
@@ -557,9 +565,12 @@ TEST(DISABLED_DiffusionTest, RungeKuttaConvergence) {
   d_grid4->Initialize();
   d_grid8->Initialize();
 
-  d_grid2->SetConcentrationThreshold(1e15);
-  d_grid4->SetConcentrationThreshold(1e15);
-  d_grid8->SetConcentrationThreshold(1e15);
+  d_grid2->SetMaxConcentration(1e15);
+  d_grid2->SetMinConcentration(-1e15);
+  d_grid4->SetMaxConcentration(1e15);
+  d_grid4->SetMinConcentration(-1e15);
+  d_grid8->SetMaxConcentration(1e15);
+  d_grid8->SetMinConcentration(-1e15);
 
   // instantaneous point source
   int init = 1e5;


### PR DESCRIPTION
I had some issues that my simulations stopped at some (random) point because some threads got stuck in the Spinlock in `ChangeConcentrationBy`. This PR implements the `omp atomic` data access to the `c1_` array. Unfortunately, `omp atomic` only supports very limited actions in the atomic region and it is not possible to accommodate the threshold checking. Therefore, this PR contains an additional statement `ApplyThreshold` in the environment's `Update` function that iterates over the grid once and trims the values according to the thresholds.

* [-] In each update, one has to iterate over the grid once. The resulting kernel should be rather efficient but it's certainly some overhead.
* [+] One can use the cheap atomic access patterns  which is rather cheap compared to e.g. a `omp critical`. Therefore, it is low in threading overhead.
* One could consider setting an additional variable `thresholds_active` that is automatically set if users set a threshold. Then, `if (thresholds_active) { ApplyThresholds (); }` to avoid unnecessary overhead.

Also this PR introduces a min concentration next to the max concentration (before threshold) because typically a temperature or a concentration is bounded by a lower value (0 K, -273.15 C, 0 mmol/L, etc.).

Alternative solutions are welcome, I guess this [-] makes the PR not perfect.