### PR TITLE
Resize locks vector in diffusion grid if the size changes

### DIFF
--- a/src/core/diffusion/diffusion_grid.cc
+++ b/src/core/diffusion/diffusion_grid.cc
@@ -284,6 +284,7 @@ void DiffusionGrid::ChangeConcentrationBy(size_t idx, double amount) {
     return;
   }
   std::lock_guard<Spinlock> guard(locks_[idx]);
+  assert(idx < locks_.size());
   c1_[idx] += amount;
   if (c1_[idx] > concentration_threshold_) {
     c1_[idx] = concentration_threshold_;
@@ -299,6 +300,7 @@ double DiffusionGrid::GetConcentration(const Double3& position) const {
                "the diffusion grid!");
     return 0;
   }
+  assert(idx < locks_.size());
   std::lock_guard<Spinlock> guard(locks_[idx]);
   return c1_[idx];
 }


### PR DESCRIPTION
Resizing happened only in the `Initialize` method.
Therefore, out-of-bounds accesses happened if the grid grew 
during the simulation.
If the out-of-bounds value was not zero, the lock appeared
to be hold by a thread which caused deadlocks.