### PR TITLE
Locate `bdm` with `find` in GHA

### DIFF
--- a/.github/workflows/macos-system-ci.yml
+++ b/.github/workflows/macos-system-ci.yml
@@ -104,7 +104,7 @@ jobs:
       shell: zsh {0}
       working-directory: build
       run: |
-        . $INSTALL_DIR/bin/thisbdm.sh
+        source $(find /Users -path "*/bin/*" -name "*thisbdm.sh")
         git config --system user.name "Test User"
         git config --system user.email user@test.com
         make run-demos


### PR DESCRIPTION
Scheduled `GHA` on macOS failed because the system was not able to source BDM. To overcome this bottleneck, we now use the `find` command to reliably locate the `bin/thisbdm.sh` script.