### PR TITLE
Remove `benchmark` as default build target

### DIFF
--- a/.github/workflows/centos-ci.yml
+++ b/.github/workflows/centos-ci.yml
@@ -86,6 +86,7 @@ jobs:
         module load mpi
         cmake -G Ninja \
           -Dparaview=ON \
+          -Dbenchmark=ON \
           -Dnuma=OFF \
           -DCMAKE_BUILD_TYPE=Release \
           -B build

--- a/.github/workflows/centos-system-ci.yml
+++ b/.github/workflows/centos-system-ci.yml
@@ -119,6 +119,7 @@ jobs:
         module load mpi
         cmake \
           -Dparaview=ON \
+          -Dbenchmark=ON \
           -Dsbml=OFF \
           -Dnuma=OFF \
           -DCMAKE_BUILD_TYPE=Release \

--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -53,6 +53,7 @@ jobs:
         cmake -G Ninja \
           -Dopencl=OFF \
           -Dparaview=ON \
+          -Dbenchmark=ON \
           -DCMAKE_BUILD_TYPE=Release \
           -B build
         cmake --build build --parallel --config Release

--- a/.github/workflows/macos-system-ci.yml
+++ b/.github/workflows/macos-system-ci.yml
@@ -92,6 +92,7 @@ jobs:
         cmake \
           -Dopencl=OFF \
           -Dparaview=ON \
+          -Dbenchmark=ON \
           -DCMAKE_BUILD_TYPE=Release \
           -B build
         cmake --build build --parallel --config Release

--- a/.github/workflows/ubuntu-ci.yml
+++ b/.github/workflows/ubuntu-ci.yml
@@ -77,6 +77,7 @@ jobs:
         pyenv shell 3.9.1
         cmake -G Ninja \
           -Dparaview=ON \
+          -Dbenchmark=ON \
           -DCMAKE_BUILD_TYPE=Release \
           -B build
         cmake --build build --parallel --config Release

--- a/.github/workflows/ubuntu-system-ci.yml
+++ b/.github/workflows/ubuntu-system-ci.yml
@@ -127,6 +127,7 @@ jobs:
         cmake \
           -Dnotebooks=OFF \
           -Dparaview=ON \
+          -Dbenchmark=ON \
           -Dsbml=OFF \
           -DCMAKE_BUILD_TYPE=Release \
           -B build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,7 +99,7 @@ mark_as_advanced(${CMAKE_BIODYNAMO_BUILD_ROOT}
 
 # Options. Turn on with 'cmake -Dmyvarname=ON'.
 option(test      "Build all tests." ON) # Makes boolean 'test' available.
-option(benchmark "Build benchmark suite." ON)
+option(benchmark "Build benchmark suite." OFF)
 option(cuda      "Enable CUDA code generation for GPU acceleration" OFF)
 option(opencl    "Enable OpenCL code generation for GPU acceleration" OFF)
 option(dict      "Build with ROOT dictionaries" ON)


### PR DESCRIPTION
We deactivate the `benchmark` build target by default to save time in the build time for developers and users. The option is explicitly activated in GHA to make sure that they keep compiling and do not get out of synchronization with the core of the repository.