### PR TITLE
Add CLI wrapper for `bam-config`

### DIFF
--- a/.github/workflows/centos-ci.yml
+++ b/.github/workflows/centos-ci.yml
@@ -97,6 +97,7 @@ jobs:
       working-directory: build
       run: |
         . bin/thisbdm.sh
+        bdm config
         export DISPLAY=:99.0
         sleep 3
         ninja run-unit-tests

--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -65,6 +65,7 @@ jobs:
         . bin/thisbdm.sh
         root --version
         root -config
+        bdm config
         ninja run-unit-tests
 
     - name: Notify Slack

--- a/.github/workflows/ubuntu-ci.yml
+++ b/.github/workflows/ubuntu-ci.yml
@@ -87,6 +87,7 @@ jobs:
       working-directory: build
       run: |
         . bin/thisbdm.sh
+        bdm config
         export DISPLAY=:99.0
         ninja run-unit-tests
 

--- a/cli/build_command.py
+++ b/cli/build_command.py
@@ -25,7 +25,7 @@ def BuildCommand(clean=False, build=True):
     Print.new_step("<bdm build> Building project ...")
 
     if clean:
-        Print.new_step("Clean build directory")
+        Print.new_step("<bdm build> Clean build directory")
         sp.check_output(["rm", "-rf", build_dir])
         sp.check_output(["mkdir", build_dir])
 

--- a/cli/config_command.py
+++ b/cli/config_command.py
@@ -1,0 +1,119 @@
+# -----------------------------------------------------------------------------
+#
+# Copyright (C) 2021 CERN & University of Surrey for the benefit of the
+# BioDynaMo collaboration. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+#
+# See the LICENSE file distributed with this work for details.
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
+#
+# -----------------------------------------------------------------------------
+
+import os
+import subprocess as sp
+from print_command import Print
+from pprint import pprint
+
+# Converts a sting to a list by splitting it with the split_char.
+def StringToList(input_string, split_char=" "):
+    output_list = input_string.split(split_char)
+    return output_list
+
+
+# Converts a list of type ["key1=value1", ... ,"keyN=valueN"] to a dictionary of
+# type {"key1":"value1", ... , "keyN" : "valueN"}.
+def ListToDir(input_list):
+    output_dir = {}
+    for element in input_list:
+        tmp_list = element.split("=")
+        output_dir[tmp_list[0]] = tmp_list[1]
+    return output_dir
+
+
+## The BioDynaMo CLI command to print the configuration of biodynamo. Obtains
+## information from <path_to_bdm>/build/bin/bdm-config
+def ConfigCommand():
+    Print.new_step("<bdm config> Loading BioDynaMo configuration ...")
+
+    # 0. Define explanations
+    explanation = {
+        "arch": "The architecture (compiler/OS)",
+        "platform": "The platform (OS)",
+        "cxxflags": "Compiler flags and header path",
+        "cxxincludes": "Only header paths (subset of cxxflags)",
+        "ldflags": "Linker flags",
+        "libs": "BioDynaMo libraries",
+        "cmakedir": "BioDynaMo cmake directory",
+        "bindir": "The executable directory",
+        "libdir": "The library directory",
+        "incdir": "The header directory",
+        "config": "The cmake configuration options",
+        "version": "The BioDynaMo version",
+        "ncpu": "Number of available (hyperthreaded) cores",
+        "cxx": "Alternative C++ compiler specified when BDM was built",
+        "ld": "Alternative Linker specified when BDM was built",
+        "cmake-invoke": "The BioDynaMo cmake invocation",
+        "root-version": "The version of ROOT used to build BioDynaMo",
+    }
+
+    # 1. Get path to bdm-config
+    bdm_config_command = os.path.join(os.environ["BDMSYS"], "bin", "bdm-config")
+
+    # 2. Extract all information via bdm-config
+    arguments = [
+        "version",
+        "root-version",
+        "cxxflags",
+        "cxxincludes",
+        "ldflags",
+        "libs",
+        "bindir",
+        "libdir",
+        "incdir",
+        "cxx",
+        "ld",
+        "cmakedir",
+        "cmake-invoke",
+        "config",
+        "arch",
+        "platform",
+        "ncpu",
+    ]
+    bdm_config = {}
+    for argument in arguments:
+        result = sp.run(
+            [bdm_config_command, "--{}".format(argument)], capture_output=True
+        )
+        bdm_config[argument] = result.stdout.decode("UTF-8").replace("\n", "")
+
+    # 3. Format fields
+    # 3.1 The following stings need to be converted to a list type.
+    list_formats = [
+        "cxxflags",
+        "cxxincludes",
+        "ldflags",
+        "libs",
+        "libdir",
+        "incdir",
+        "ld",
+        "config",
+    ]
+    for lf in list_formats:
+        bdm_config[lf] = StringToList(bdm_config[lf])
+    # 3.2 The following lists need to be converted to a dictionary type.
+    dict_formats = [
+        "config",
+    ]
+    for df in dict_formats:
+        bdm_config[df] = ListToDir(bdm_config[df])
+
+    # 4. Print explanation and configuration
+    for x in arguments:
+        Print.new_step_in_config(x, explanation[x])
+        pprint(bdm_config[x])
+
+    # 5. Finalize
+    Print.new_step("<bdm config> Finished successfully ...")

--- a/cli/main.py
+++ b/cli/main.py
@@ -20,6 +20,7 @@ from demo_command import DemoCommand
 from new_command import NewCommand
 from run_command import RunCommand
 from test_command import TestCommand
+from config_command import ConfigCommand
 from bdm_version import Version
 
 
@@ -46,6 +47,8 @@ def Main():
 
     clean_sp = sp.add_parser("clean", help="Removes all build files")
 
+    config_sp = sp.add_parser("config", help="Prints the configuration of BDM.")
+
     demo_sp = sp.add_parser("demo", help="Creates pre-built demos.")
 
     new_sp = sp.add_parser(
@@ -63,7 +66,7 @@ def Main():
     run_sp = sp.add_parser("run", help="Executes the simulation")
 
     test_sp = sp.add_parser(
-        "test", help="Executes the unit-tests of a BioDynaMo sim."
+        "test", help="Executes the unit-tests of a BioDynaMo simulation."
     )
 
     args, unknown = parser.parse_known_args()
@@ -83,6 +86,8 @@ def Main():
             clean_sp.print_help()
             sys.exit()
         BuildCommand(clean=True, build=False)
+    elif args.cmd == "config":
+        ConfigCommand()
     elif args.cmd == "demo":
         demo_name = None
         destination = None

--- a/cli/print_command.py
+++ b/cli/print_command.py
@@ -40,3 +40,16 @@ class Print:
     @staticmethod
     def new_step(message):
         print("\n" + Print.BOLD + Print.BLUE + str(message) + Print.END)
+
+    @staticmethod
+    def new_step_in_config(message1, message2):
+        print(
+            "\n"
+            + Print.BOLD
+            + Print.GREEN
+            + str(message1)
+            + Print.END
+            + " ("
+            + str(message2)
+            + ")"
+        )


### PR DESCRIPTION
Usage:
```
. <path_to_bdm>/build/bin/thisbdm.sh
bdm config
```

Example output:
```
<bdm config> Loading BioDynaMo configuration ...

version (The BioDynaMo version)
'v1.03.6-e9439619'

root-version (The version of ROOT used to build BioDynaMo)
'6.25/01'

cxxflags (Compiler flags and header path)
[ '-DUSE_DICT',
 '-std=c++14',
 '-Wall',
 '-Wno-missing-braces',
 '-m64',
 '-fPIC',
 '-Xclang',
 '-fopenmp',
 '-Wno-undefined-var-template',
 '-stdlib=libc++',
 '-pthread',
 '-std=c++14',
 '-m64']

[ ... ]

<bdm config> Finished successfully ...
```