### PR TITLE
Fix compiler warnings

### DIFF
--- a/test/unit/core/agent/agent_test.cc
+++ b/test/unit/core/agent/agent_test.cc
@@ -303,7 +303,6 @@ TEST(AgentTest, StaticnessNeighbors) {
   auto* neighbor = new Cell({10, 0, 0});
   neighbor->SetDiameter(10);
   neighbor->AddBehavior(new CaptureStaticness(&static_agents_map));
-  auto nptr = neighbor->GetAgentPtr<Cell>();
   auto nuid = neighbor->GetUid();
 
   // should be false right after creation
@@ -347,13 +346,11 @@ TEST(AgentTest, StaticnessNewAgent) {
   auto* agent1 = new Cell({0, 0, 0});
   agent1->SetDiameter(10);
   agent1->AddBehavior(new CaptureStaticness(&static_agents_map));
-  auto aptr1 = agent1->GetAgentPtr<Cell>();
   auto auid1 = agent1->GetUid();
 
   auto* agent2 = new Cell({10, 0, 0});
   agent2->SetDiameter(10);
   agent2->AddBehavior(new CaptureStaticness(&static_agents_map));
-  auto aptr2 = agent2->GetAgentPtr<Cell>();
   auto auid2 = agent2->GetUid();
 
   auto* agent3 = new Cell({30, 0, 0});
@@ -396,7 +393,6 @@ TEST(AgentTest, StaticnessNewAgent) {
   //   big enough to overlap with agent1 and agent2
   new_agent->SetDiameter(12);
   new_agent->AddBehavior(new CaptureStaticness(&static_agents_map));
-  auto naptr = new_agent->GetAgentPtr<Cell>();
   auto nauid = new_agent->GetUid();
   rm->AddAgent(new_agent);
 
@@ -427,13 +423,11 @@ TEST(AgentTest, StaticnessNewAgentLargetThanAllOthers) {
   auto* agent1 = new Cell({0, 0, 0});
   agent1->SetDiameter(10);
   agent1->AddBehavior(new CaptureStaticness(&static_agents_map));
-  auto aptr1 = agent1->GetAgentPtr<Cell>();
   auto auid1 = agent1->GetUid();
 
   auto* agent2 = new Cell({10, 0, 0});
   agent2->SetDiameter(10);
   agent2->AddBehavior(new CaptureStaticness(&static_agents_map));
-  auto aptr2 = agent2->GetAgentPtr<Cell>();
   auto auid2 = agent2->GetUid();
 
   auto* agent3 = new Cell({30, 0, 0});

--- a/test/unit/core/resource_manager_test.h
+++ b/test/unit/core/resource_manager_test.h
@@ -461,9 +461,12 @@ struct CheckNumaThreadErrors : Functor<void, Agent*, AgentHandle> {
   void operator()(Agent* agent, AgentHandle handle) override {
     volatile double d = 0;
     for (int i = 0; i < 10000; i++) {
-      d += std::sin(i);
+      d += std::abs(std::sin(i));
     }
-    if (handle.GetNumaNode() != ti_->GetNumaNode(omp_get_thread_num())) {
+    // The second condition (d != 0.0) is always true and is just used to avoid
+    // compiler warnings from `Wunused-but-set-variable`.
+    if (handle.GetNumaNode() != ti_->GetNumaNode(omp_get_thread_num()) &&
+        d != 0.0) {
       numa_thread_errors++;
     }
   }


### PR DESCRIPTION
This PR fixes the following compiler warnings:

```
[493/533] Building CXX object CMakeFiles/biodynamo-unit-tests.dir/test/unit/core/agent/agent_test.cc.o
/Users/rdm/biodynamo/test/unit/core/agent/agent_test.cc:306:8: warning: unused variable 'nptr' [-Wunused-variable]
  auto nptr = neighbor->GetAgentPtr<Cell>();
       ^
/Users/rdm/biodynamo/test/unit/core/agent/agent_test.cc:350:8: warning: unused variable 'aptr1' [-Wunused-variable]
  auto aptr1 = agent1->GetAgentPtr<Cell>();
       ^
/Users/rdm/biodynamo/test/unit/core/agent/agent_test.cc:356:8: warning: unused variable 'aptr2' [-Wunused-variable]
  auto aptr2 = agent2->GetAgentPtr<Cell>();
       ^
/Users/rdm/biodynamo/test/unit/core/agent/agent_test.cc:399:8: warning: unused variable 'naptr' [-Wunused-variable]
  auto naptr = new_agent->GetAgentPtr<Cell>();
       ^
/Users/rdm/biodynamo/test/unit/core/agent/agent_test.cc:430:8: warning: unused variable 'aptr1' [-Wunused-variable]
  auto aptr1 = agent1->GetAgentPtr<Cell>();
       ^
/Users/rdm/biodynamo/test/unit/core/agent/agent_test.cc:436:8: warning: unused variable 'aptr2' [-Wunused-variable]
  auto aptr2 = agent2->GetAgentPtr<Cell>();
       ^
6 warnings generated.
[509/533] Building CXX object CMakeFiles/biodynamo-unit-tests.dir/libbiodynamo-unit-tests_dict.cc.o
In file included from /Users/rdm/biodynamo/build/libbiodynamo-unit-tests_dict.cc:49:
/Users/rdm/biodynamo/test/unit/core/resource_manager_test.h:462:21: warning: variable 'd' set but not used [-Wunused-but-set-variable]
    volatile double d = 0;
                    ^
1 warning generated.
[529/533] Building CXX object CMakeFiles/biodynamo-unit-tests.dir/test/unit/core/resource_manager_test.cc.o
In file included from /Users/rdm/biodynamo/test/unit/core/resource_manager_test.cc:16:
/Users/rdm/biodynamo/test/unit/core/resource_manager_test.h:462:21: warning: variable 'd' set but not used [-Wunused-but-set-variable]
    volatile double d = 0;
                    ^
1 warning generated.
[533/533] Linking CXX executable bin/biodynamo-unit-tests
```