### PR TITLE
Add left-multiplication to MathArray

### DIFF
--- a/src/core/container/math_array.h
+++ b/src/core/container/math_array.h
@@ -400,6 +400,17 @@ std::ostream& operator<<(std::ostream& o, const MathArray<T, N>& arr) {
   return o;
 }
 
+// Note: 1) We pass by value to allow for copy-elision and move semantics
+//          optimization.
+//       2) We do return MathArray<T, N> because a const MathArray<T, N>
+//          prevents move semantics in C++11.
+//       see https://tinyurl.com/left-multiply
+/// Template function to multiply array with scalar from the left.
+template <class T, std::size_t N>
+MathArray<T, N> operator*(T const& scalar, MathArray<T, N> array) {
+  return array *= scalar;
+}
+
 /// Alias for a size 3 MathArray
 using Double3 = MathArray<double, 3>;
 

--- a/test/unit/core/container/math_array_test.cc
+++ b/test/unit/core/container/math_array_test.cc
@@ -89,6 +89,29 @@ TEST(MathArray, math_operators) {
   ASSERT_EQ(b, decrement_result);
 }
 
+TEST(MathArray, scalar_multiplication_from_left) {
+  // Define objects for test calculation
+  double scalar{1.25};
+  MathArray<double, 4> a{0, 1, 2, 3};
+  const MathArray<double, 4> b{1, 2, 3, 4};
+
+  // Define expected results
+  MathArray<double, 4> a_result{0, 1.25, 2.5, 3.75};
+  MathArray<double, 4> b_result{1.25, 2.5, 3.75, 5.0};
+
+  // Compute scalar multiplications
+  MathArray<double, 4> a1 = a * scalar;
+  MathArray<double, 4> a2 = scalar * a;
+  MathArray<double, 4> b1 = b * scalar;
+  MathArray<double, 4> b2 = scalar * b;
+
+  // Check if we match the expected results
+  EXPECT_TRUE(a1 == a_result);
+  EXPECT_TRUE(a2 == a_result);
+  EXPECT_TRUE(b1 == b_result);
+  EXPECT_TRUE(b2 == b_result);
+}
+
 TEST(MathArray, complex_operations) {
   MathArray<double, 3> a;
   MathArray<double, 4> b{0, 0, 0, 0};

--- a/test/unit/core/container/math_array_test.cc
+++ b/test/unit/core/container/math_array_test.cc
@@ -28,7 +28,7 @@ TEST(MathArray, DefaultConstructor) {
   EXPECT_NEAR(0.0, a[2], abs_error<double>::value);
 }
 
-TEST(MathArray, element_access) {
+TEST(MathArray, ElementAccess) {
   MathArray<double, 4> real_vector{0, 1, 2, 3};
 
   for (int i = 0; i < 4; i++) {
@@ -46,7 +46,7 @@ TEST(MathArray, element_access) {
   }
 }
 
-TEST(MathArray, capacity) {
+TEST(MathArray, Capacity) {
   MathArray<double, 4> real_vector{0, 1, 2, 3};
   MathArray<double, 0> real_vector_empty;
 
@@ -57,7 +57,7 @@ TEST(MathArray, capacity) {
   ASSERT_TRUE(real_vector_empty.empty());
 }
 
-TEST(MathArray, math_operators) {
+TEST(MathArray, MathOperators) {
   MathArray<double, 4> a{0, 1, 2, 3};
   MathArray<double, 4> b{0, 1, 2, 3};
 
@@ -89,7 +89,7 @@ TEST(MathArray, math_operators) {
   ASSERT_EQ(b, decrement_result);
 }
 
-TEST(MathArray, scalar_multiplication_from_left) {
+TEST(MathArray, ScalarMultiplicationFromLeft) {
   // Define objects for test calculation
   double scalar{1.25};
   MathArray<double, 4> a{0, 1, 2, 3};
@@ -112,7 +112,7 @@ TEST(MathArray, scalar_multiplication_from_left) {
   EXPECT_TRUE(b2 == b_result);
 }
 
-TEST(MathArray, complex_operations) {
+TEST(MathArray, ComplexOperations) {
   MathArray<double, 3> a;
   MathArray<double, 4> b{0, 0, 0, 0};
   MathArray<double, 4> c{1, 2, 3, 4};


### PR DESCRIPTION
Previously:

```cpp
root [1] Double3 x {1,2,3};
root [2] x * 4.0
(bdm::MathArray) { 4.0000000, 8.0000000, 12.000000 }
root [3] 4.0 * x
ROOT_prompt_3:1:5: error: invalid operands to binary expression ('double' and 'bdm::Double3' (aka 'MathArray<double, 3>'))
4.0 * x
~~~ ^ ~
/Users/tobias/tmp/biodynamo/build/third_party/root/include/TH1.h:483:6: note: candidate function not viable: no known conversion from 'bdm::Double3' (aka 'MathArray<double, 3>') to 'const TH1C' for 2nd argument
TH1C operator*(Double_t c1, const TH1C &h1);
     ^
[... lengthy output ...]
```

Now:
```cpp
root [1] Double3 x {1,2,3};
root [2] x * 4.0
(bdm::MathArray) { 4.0000000, 8.0000000, 12.000000 }
root [3] 4.0 * x
(bdm::MathArray<double, 3UL>) { 4.0000000, 8.0000000, 12.000000 }
```






