### PR TITLE
Extend DiffusionGrid interface for full gradient information

### DIFF
--- a/src/core/container/math_array.h
+++ b/src/core/container/math_array.h
@@ -336,6 +336,16 @@ class MathArray {  // NOLINT
   /// \return sum of the array's content.
   T Sum() const { return std::accumulate(begin(), end(), 0); }
 
+  /// Checks if vector is a zero vector, e.g. if all entries are zero.
+  bool IsZero() const {
+    for (size_t i = 0; i < N; i++) {
+      if (data_[i] != 0) {
+        return false;
+      }
+    }
+    return true;
+  }
+
   /// Compute the norm of the array's content.
   /// \return array's norm.
   T Norm() const {

--- a/src/core/diffusion/diffusion_grid.cc
+++ b/src/core/diffusion/diffusion_grid.cc
@@ -337,10 +337,8 @@ void DiffusionGrid::GetGradient(const Double3& position, Double3* gradient,
     return;
   }
   *gradient = gradients_[idx];
-  if (normalize) {
-    if (!gradient->IsZero()) {
-      gradient->Normalize();
-    }
+  if (normalize && !gradient->IsZero()) {
+    gradient->Normalize();
   }
 }
 

--- a/src/core/diffusion/diffusion_grid.cc
+++ b/src/core/diffusion/diffusion_grid.cc
@@ -327,9 +327,8 @@ double DiffusionGrid::GetConcentration(const Double3& position) const {
   return c1_[idx];
 }
 
-/// Get the (normalized) gradient at specified position
-void DiffusionGrid::GetGradient(const Double3& position,
-                                Double3* gradient) const {
+void DiffusionGrid::GetGradient(const Double3& position, Double3* gradient,
+                                bool normalize) const {
   auto idx = GetBoxIndex(position);
   if (idx >= total_num_boxes_) {
     Log::Error("DiffusionGrid::GetGradient",
@@ -338,8 +337,7 @@ void DiffusionGrid::GetGradient(const Double3& position,
     return;
   }
   *gradient = gradients_[idx];
-  auto norm = gradient->Norm();
-  if (norm > 1e-10) {
+  if (normalize) {
     gradient->Normalize();
   }
 }

--- a/src/core/diffusion/diffusion_grid.cc
+++ b/src/core/diffusion/diffusion_grid.cc
@@ -338,7 +338,9 @@ void DiffusionGrid::GetGradient(const Double3& position, Double3* gradient,
   }
   *gradient = gradients_[idx];
   if (normalize) {
-    gradient->Normalize();
+    if (!gradient->IsZero()) {
+      gradient->Normalize();
+    }
   }
 }
 

--- a/src/core/diffusion/diffusion_grid.h
+++ b/src/core/diffusion/diffusion_grid.h
@@ -79,9 +79,10 @@ class DiffusionGrid {
   // NOTE: virtual because of test
   /// Get the gradient at a specified position. By default, the obtained
   /// gradient is scaled to norm 1, but with `normalize = false` one can obtain
-  /// the full gradient information (e.g. the un-normalized gradient). Note that
-  /// the gradient is computed via a central difference scheme on the underlying
-  /// spatial discretization.
+  /// the full gradient information (e.g. the un-normalized gradient). If the
+  /// gradient is zero and `normalize = true`, this method returns a zero
+  /// vector. Note that the gradient is computed via a central difference scheme
+  /// on the underlying spatial discretization.
   virtual void GetGradient(const Double3& position, Double3* gradient,
                            bool normalize = true) const;
 

--- a/src/core/diffusion/diffusion_grid.h
+++ b/src/core/diffusion/diffusion_grid.h
@@ -76,9 +76,14 @@ class DiffusionGrid {
   /// Get the concentration at specified position
   double GetConcentration(const Double3& position) const;
 
-  /// Get the (normalized) gradient at specified position
-  // TODO: virtual because of test
-  virtual void GetGradient(const Double3& position, Double3* gradient) const;
+  // NOTE: virtual because of test
+  /// Get the gradient at a specified position. By default, the obtained
+  /// gradient is scaled to norm 1, but with `normalize = false` one can obtain
+  /// the full gradient information (e.g. the un-normalized gradient). Note that
+  /// the gradient is computed via a central difference scheme on the underlying
+  /// spatial discretization.
+  virtual void GetGradient(const Double3& position, Double3* gradient,
+                           bool normalize = true) const;
 
   std::array<uint32_t, 3> GetBoxCoordinates(const Double3& position) const;
 

--- a/test/unit/core/behavior/chemotaxis_test.cc
+++ b/test/unit/core/behavior/chemotaxis_test.cc
@@ -25,7 +25,8 @@ struct TestDiffusionGrid : public EulerGrid {
       : EulerGrid(0, "TestSubstance", 1, 1),
         normalized_gradient_(normalized_gradient) {}
 
-  void GetGradient(const Double3& position, Double3* gradient) const override {
+  void GetGradient(const Double3& position, Double3* gradient,
+                   bool normalize = true) const override {
     (*gradient) = normalized_gradient_;
   }
 

--- a/test/unit/core/container/math_array_test.cc
+++ b/test/unit/core/container/math_array_test.cc
@@ -165,6 +165,13 @@ TEST(MathArray, GetNormalizedArray) {
   EXPECT_DOUBLE_EQ(d[2], a[2]);
 }
 
+TEST(MathArray, IsZero) {
+  Double3 x = {0, 0, 0};
+  Double3 y = {0, 0, 0.01};
+  EXPECT_TRUE(x.IsZero());
+  EXPECT_FALSE(y.IsZero());
+}
+
 TEST(MathArray, NormalizeZeroVectorDeath) {
   EXPECT_DEATH_IF_SUPPORTED(
       {

--- a/util/installation/osx/prerequisites.sh
+++ b/util/installation/osx/prerequisites.sh
@@ -56,7 +56,9 @@ brew install \
 
 # Install the optional packages
 if [ $1 == "all" ]; then
-    PIP_PACKAGES="nbformat jupyter metakernel jupyterlab"
+    # Fix jinja2 version because of failing build target `notebooks` on 
+    # macOS System CI.
+    PIP_PACKAGES="nbformat jupyter metakernel jupyterlab jinja2=3.0"
     # Don't install --user: the packages should end up in the PYENV_ROOT directory
     python3.9 -m pip install $PIP_PACKAGES
     brew install \

--- a/util/installation/osx/prerequisites.sh
+++ b/util/installation/osx/prerequisites.sh
@@ -58,7 +58,7 @@ brew install \
 if [ $1 == "all" ]; then
     # Fix jinja2 version because of failing build target `notebooks` on 
     # macOS System CI.
-    PIP_PACKAGES="nbformat jupyter metakernel jupyterlab jinja2=3.0"
+    PIP_PACKAGES="nbformat jupyter metakernel jupyterlab jinja2==3.0"
     # Don't install --user: the packages should end up in the PYENV_ROOT directory
     python3.9 -m pip install $PIP_PACKAGES
     brew install \


### PR DESCRIPTION
This PR makes the `DiffusionGrid::GetGradient` more flexible. It allows retrieving the absolute value of the gradient such that modelers can use the full information of the gradient, e.g. define behaviors that are only executed if the gradient is stronger than a certain threshold. 

Furthermore, the PR introduces a UnitTest to verify that the gradients are computed correctly by comparing an analytic and numeric solution.

