### PR TITLE
Fix normalization of the diffusion gradient

### DIFF
--- a/src/core/container/math_array.h
+++ b/src/core/container/math_array.h
@@ -362,6 +362,14 @@ class MathArray {  // NOLINT
   /// Normalize the array in-place.
   void Normalize() {
     T norm = Norm();
+    Normalize(norm);
+  }
+
+  /// Normalize the array in-place.\n
+  /// If the calling code has already calculated the norm,
+  /// this function signature ensures that the norm calculation
+  /// is not duplicated.
+  void Normalize(T norm) {
     if (norm == 0) {
       Log::Fatal("MathArray::Normalize",
                  "You tried to normalize a zero vector. "

--- a/src/core/diffusion/diffusion_grid.cc
+++ b/src/core/diffusion/diffusion_grid.cc
@@ -337,8 +337,11 @@ void DiffusionGrid::GetGradient(const Double3& position, Double3* gradient,
     return;
   }
   *gradient = gradients_[idx];
-  if (normalize && !gradient->IsZero()) {
-    gradient->Normalize();
+  if (normalize) {
+    auto norm = gradient->Norm();
+    if (norm > 1e-10) {
+      gradient->Normalize(norm);
+    }
   }
 }
 

--- a/test/unit/core/container/math_array_test.cc
+++ b/test/unit/core/container/math_array_test.cc
@@ -172,6 +172,21 @@ TEST(MathArray, IsZero) {
   EXPECT_FALSE(y.IsZero());
 }
 
+TEST(MathArray, Normalize) {
+  MathArray<double, 3> a{1.1, 2.2, 3.3};
+  MathArray<double, 3> b{1.1, 2.2, 3.3};
+
+  a.Normalize();
+  EXPECT_DOUBLE_EQ(0.2672612419124244187, a[0]);
+  EXPECT_DOUBLE_EQ(0.5345224838248488374, a[1]);
+  EXPECT_DOUBLE_EQ(0.8017837257372732561, a[2]);
+
+  b.Normalize(b.Norm());
+  EXPECT_DOUBLE_EQ(0.2672612419124244187, b[0]);
+  EXPECT_DOUBLE_EQ(0.5345224838248488374, b[1]);
+  EXPECT_DOUBLE_EQ(0.8017837257372732561, b[2]);
+}
+
 TEST(MathArray, NormalizeZeroVectorDeath) {
   EXPECT_DEATH_IF_SUPPORTED(
       {


### PR DESCRIPTION
Even if gradient.IsZero() is false, gradient.Norm() can evaluate to 0.
e.g. if gradient is: {0, 0, 1.4013e-45}