### PR TITLE
Fix warning in multi-simulation mode

### DIFF
--- a/demo/epidemiology/src/epidemiology.cc
+++ b/demo/epidemiology/src/epidemiology.cc
@@ -71,7 +71,7 @@ int main(int argc, const char** argv) {
   } else {  // Run the multi-simulation fitting routine
     // Generate the analytical data
     auto analytical = GetAnalyticalResults(param);
-    MultiSimulation pe(argc, argv, analytical);
+    MultiSimulation pe(argc, argv, &analytical);
     std::cout << "Simulation completed successfully!" << std::endl;
     return pe.Execute(Simulate);
   }

--- a/src/core/multi_simulation/database.h
+++ b/src/core/multi_simulation/database.h
@@ -26,7 +26,7 @@ using experimental::TimeSeries;
 /// for the purpose of parameter optimization
 class Database {
  public:
-  TimeSeries data_;
+  TimeSeries* data_ = nullptr;
 
   static Database* GetInstance() {
     static Database kDatabase;

--- a/src/core/multi_simulation/experiment.h
+++ b/src/core/multi_simulation/experiment.h
@@ -42,7 +42,7 @@ inline real_t Experiment(
   // the database
   bool use_real_data = true;
   if (!real_ts) {
-    real_ts = &(Database::GetInstance()->data_);
+    real_ts = Database::GetInstance()->data_;
     // If also no real data is present in the database, we just run the
     // simulation
     if (!real_ts) {

--- a/src/core/multi_simulation/multi_simulation.cc
+++ b/src/core/multi_simulation/multi_simulation.cc
@@ -44,8 +44,7 @@ MultiSimulation::MultiSimulation(int argc, const char** argv)
   argv_copy_[argc_] = nullptr;
 }
 
-MultiSimulation::MultiSimulation(int argc, const char** argv,
-                                 TimeSeries* real)
+MultiSimulation::MultiSimulation(int argc, const char** argv, TimeSeries* real)
     : MultiSimulation(argc, argv) {
   // Register the real data to the database
   auto* db = Database::GetInstance();

--- a/src/core/multi_simulation/multi_simulation.cc
+++ b/src/core/multi_simulation/multi_simulation.cc
@@ -45,7 +45,7 @@ MultiSimulation::MultiSimulation(int argc, const char** argv)
 }
 
 MultiSimulation::MultiSimulation(int argc, const char** argv,
-                                 const TimeSeries& real)
+                                 TimeSeries* real)
     : MultiSimulation(argc, argv) {
   // Register the real data to the database
   auto* db = Database::GetInstance();

--- a/src/core/multi_simulation/multi_simulation.h
+++ b/src/core/multi_simulation/multi_simulation.h
@@ -35,7 +35,7 @@ class MultiSimulation {
  public:
   MultiSimulation(int argc, const char** argv);
 
-  MultiSimulation(int argc, const char** argv, const TimeSeries& real);
+  MultiSimulation(int argc, const char** argv, TimeSeries* real);
 
   ~MultiSimulation();
 


### PR DESCRIPTION
The check of whether real data was present in our Database class
was always evaluating to true, because it was an object on the
stack. Changed that into a pointer, so that can be evaluated for
nullptr when no Database object is created