### PR TITLE
Fix issue with markupsafe which breaks nbconvert and thus the website

### DIFF
--- a/doc/user_guide/prerequisites.md
+++ b/doc/user_guide/prerequisites.md
@@ -101,7 +101,7 @@ PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.9.1
 
 ```bash
 pyenv shell 3.9.1
-python -m pip install nbformat jupyter metakernel jupyterlab
+python -m pip install markupsafe==2.0.1 jupyter metakernel jupyterlab nbformat==5.4.0 nbconvert==6.5.3 nbclient==0.6.6
 sudo apt-get install -y valgrind \
   clang-format clang-tidy \
   doxygen graphviz libxml2-dev libgsl-dev
@@ -189,7 +189,7 @@ PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.9.1
 
 ```bash
 pyenv shell 3.9.1
-python -m pip install nbformat jupyter metakernel jupyterlab
+python -m pip install markupsafe==2.0.1 nbformat jupyter metakernel jupyterlab nbformat==5.4.0 nbconvert==6.5.3 nbclient==0.6.6
 # SBML integration
 sudo bash -c 'cat << EOF  > /etc/yum.repos.d/springdale-7-SCL.repo
 [SCL-core]
@@ -249,5 +249,5 @@ brew install libomp open-mpi python@3.9 wget cmake ninja bash tbb qt@5
 
 ```bash
 brew install doxygen graphviz kcov gsl
-python3 -m pip install nbformat jupyter metakernel jupyterlab 
+python3 -m pip install markupsafe==2.0.1 nbformat jupyter metakernel jupyterlab jinja2==3.0
 ```

--- a/util/installation/centos-7/prerequisites.sh
+++ b/util/installation/centos-7/prerequisites.sh
@@ -69,7 +69,7 @@ pyenv shell $PYVERS
 
 # Install optional packages
 if [ $1 == "all" ]; then
-  PIP_PACKAGES="nbformat jupyter metakernel jupyterlab nbformat==5.4.0 nbconvert==6.5.3 nbclient==0.6.6"
+  PIP_PACKAGES="markupsafe==2.0.1 nbformat jupyter metakernel jupyterlab nbformat==5.4.0 nbconvert==6.5.3 nbclient==0.6.6"
   # Don't install --user: the packages should end up in the PYENV_ROOT directory
   python -m pip install $PIP_PACKAGES
   # SBML integration

--- a/util/installation/osx/prerequisites.sh
+++ b/util/installation/osx/prerequisites.sh
@@ -58,7 +58,7 @@ brew install \
 if [ $1 == "all" ]; then
     # Fix jinja2 version because of failing build target `notebooks` on 
     # macOS System CI.
-    PIP_PACKAGES="nbformat jupyter metakernel jupyterlab jinja2==3.0"
+    PIP_PACKAGES="markupsafe==2.0.1 nbformat jupyter metakernel jupyterlab jinja2==3.0"
     # Don't install --user: the packages should end up in the PYENV_ROOT directory
     python3.9 -m pip install $PIP_PACKAGES
     brew install \

--- a/util/installation/ubuntu-18.04/prerequisites.sh
+++ b/util/installation/ubuntu-18.04/prerequisites.sh
@@ -72,7 +72,7 @@ pyenv shell $PYVERS
 # Install optional packages
 if [ $1 == "all" ]; then
   # this updates pip, but installs the updated version in $HOME/.local/bin
-  PIP_PACKAGES="jupyter metakernel jupyterlab nbformat==5.4.0 nbconvert==6.5.3 nbclient==0.6.6"
+  PIP_PACKAGES="markupsafe==2.0.1 jupyter metakernel jupyterlab nbformat==5.4.0 nbconvert==6.5.3 nbclient==0.6.6"
   # Don't install --user: the packages should end up in the PYENV_ROOT directory
   python -m pip install $PIP_PACKAGES
 


### PR DESCRIPTION
The latest version of markupsafe removed `soft_unicode` which is used by jupyter's nbconvert.
Therefore, we hardcode the markupsafe version which still contains the symbol.