### PR TITLE
Allow both manual and automatic randomization of agents ordering

### DIFF
--- a/test/unit/core/randomized_rm_test.cc
+++ b/test/unit/core/randomized_rm_test.cc
@@ -69,4 +69,64 @@ TEST(RandomizedRm, Basics) {
   EXPECT_EQ(called_copy1, called);
 }
 
+TEST(RandomizedRm, Manual) {
+  Simulation simulation(TEST_NAME);
+  int n = 10;
+  auto* rm = new RandomizedRm<ResourceManager>(false);
+  simulation.SetResourceManager(rm);
+
+  for (int i = 0; i < n; i++) {
+    rm->AddAgent(new TestAgent(i));
+  }
+
+  std::vector<int> called;
+  auto functor = L2F([&](Agent* a, AgentHandle) {
+    called.push_back(bdm_static_cast<TestAgent*>(a)->GetData());
+  });
+  rm->ForEachAgent(functor);
+  EXPECT_EQ(static_cast<uint64_t>(n), called.size());
+  for (uint64_t i = 0; i < called.size(); i++) {
+    EXPECT_EQ(static_cast<int>(i), called[i]);
+  }
+
+  // trigger randomization (with auto_randomization off)
+  rm->EndOfIteration();
+
+  // We expect a non-randomized order here
+  auto called_copy = called;
+  called.clear();
+  rm->ForEachAgent(functor);
+  EXPECT_EQ(called_copy, called);
+  EXPECT_EQ(static_cast<uint64_t>(n), called.size());
+
+  // Manually trigger the reordering of agents
+  rm->RandomizeAgentsOrder();
+
+  // We expect a randomized order here
+  auto called_copy1 = called;
+  called.clear();
+  rm->ForEachAgent(functor);
+  EXPECT_TRUE(called_copy1 != called);
+  EXPECT_EQ(static_cast<uint64_t>(n), called.size());
+  auto called_copy2 = called;
+
+  // check that every entry is unique in the randomized ordered vector
+  std::sort(called.begin(), called.end());
+  for (uint64_t i = 1; i < called.size(); ++i) {
+    EXPECT_TRUE(called[i - 1] != called[i]);
+  }
+
+  // check if agent uid map points to correct agent
+  for (int i = 0; i < n; ++i) {
+    AgentUid uid(i);
+    auto* a = bdm_static_cast<TestAgent*>(rm->GetAgent(uid));
+    EXPECT_EQ(i, a->GetData());
+  }
+
+  // check if results are stable within the same iteration
+  called.clear();
+  rm->ForEachAgent(functor);
+  EXPECT_EQ(called_copy2, called);
+}
+
 }  // namespace bdm


### PR DESCRIPTION
By default, the random reordering happens at the end of every iterations (during the teardown operation), but with this PR this can be turned off by initializing the `auto_randomize_` variable of the `RandomizedRm` class with `false`. To manually trigger the random reordering of agents, you can call the `RandomizedRm::RandomizeAgentsOrder` function.