### PR TITLE
Fix macos openmp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,19 @@ else()
 endif()
 message(STATUS "Detected OS: ${DETECTED_OS_VERS}")
 
+if(APPLE)
+  find_program(BREW_BIN brew)
+  if(BREW_BIN)
+    execute_process(COMMAND ${BREW_BIN} --prefix llvm
+                    OUTPUT_VARIABLE LLVM_BREW_PREFIX
+                    OUTPUT_STRIP_TRAILING_WHITESPACE)
+    execute_process(COMMAND ${BREW_BIN} --prefix
+                        OUTPUT_VARIABLE BREW_PREFIX
+                        OUTPUT_STRIP_TRAILING_WHITESPACE)
+  endif()
+  # Necessary to find the OpenMP library
+  set(ENV{LDFLAGS} "-L${BREW_PREFIX}/opt/libomp/lib")
+endif(APPLE)
 
 # Find a suitable compiler
 include(CheckCompiler)
@@ -119,16 +132,6 @@ option(rpath     "Link libraries with built-in RPATH (run-time search path)." OF
 option(real_t    "Define data type for real numbers. Currently supported: float, double" double)
 
 if(APPLE)
-  find_program(BREW_BIN brew)
-  if(BREW_BIN)
-    execute_process(COMMAND ${BREW_BIN} --prefix llvm
-                    OUTPUT_VARIABLE LLVM_BREW_PREFIX
-                    OUTPUT_STRIP_TRAILING_WHITESPACE)
-    execute_process(COMMAND ${BREW_BIN} --prefix
-                        OUTPUT_VARIABLE BREW_PREFIX
-                        OUTPUT_STRIP_TRAILING_WHITESPACE)
-  endif()
-  
   # ParaView on Apple devices
   set(CMAKE_BDM_PVVERSION "5.10")
   
@@ -246,6 +249,16 @@ if(paraview)
       SET(paraview OFF)
   endif()
 endif()
+
+if(APPLE)
+  # After migrating to libomp 15.0.3, libomp does no longer symlink into 
+  # $(brew --prefix)/lib/libomp.dylib. Instead, it is located in 
+  # $(brew --prefix)/opt/libomp/.. . This fix should work accross all platforms.
+  # find_package(OpenMP) can be guieded with OpenMP_<lang>_INCLUDE_DIR.
+  set(CMAKE_CPP_FLAGS "${CMAKE_CPP_FLAGS} -I${BREW_PREFIX}/opt/libomp/include")
+  set(OpenMP_C_INCLUDE_DIR "${BREW_PREFIX}/opt/libomp/include")
+  set(OpenMP_CXX_INCLUDE_DIR "${BREW_PREFIX}/opt/libomp/include")
+endif(APPLE)
 
 # Check if we have a compatible openmp compiler
 find_package(OpenMP)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,15 +63,18 @@ message(STATUS "Detected OS: ${DETECTED_OS_VERS}")
 if(APPLE)
   find_program(BREW_BIN brew)
   if(BREW_BIN)
+    execute_process(COMMAND ${BREW_BIN} --prefix
+                    OUTPUT_VARIABLE BREW_PREFIX
+                    OUTPUT_STRIP_TRAILING_WHITESPACE)
     execute_process(COMMAND ${BREW_BIN} --prefix llvm
                     OUTPUT_VARIABLE LLVM_BREW_PREFIX
                     OUTPUT_STRIP_TRAILING_WHITESPACE)
-    execute_process(COMMAND ${BREW_BIN} --prefix
-                        OUTPUT_VARIABLE BREW_PREFIX
-                        OUTPUT_STRIP_TRAILING_WHITESPACE)
+    execute_process(COMMAND ${BREW_BIN} --prefix libomp
+                    OUTPUT_VARIABLE LIBOMP_BREW_PREFIX
+                    OUTPUT_STRIP_TRAILING_WHITESPACE)
   endif()
   # Necessary to find the OpenMP library
-  set(ENV{LDFLAGS} "-L${BREW_PREFIX}/opt/libomp/lib")
+  set(ENV{LDFLAGS} "$ENV{LDFLAGS} -L${LIBOMP_BREW_PREFIX}/lib")
 endif(APPLE)
 
 # Find a suitable compiler
@@ -251,13 +254,13 @@ if(paraview)
 endif()
 
 if(APPLE)
-  # After migrating to libomp 15.0.3, libomp does no longer symlink into 
+  # After migrating to libomp 15.0.3, libomp is no longer symlinked into 
   # $(brew --prefix)/lib/libomp.dylib. Instead, it is located in 
-  # $(brew --prefix)/opt/libomp/.. . This fix should work accross all platforms.
-  # find_package(OpenMP) can be guieded with OpenMP_<lang>_INCLUDE_DIR.
-  set(CMAKE_CPP_FLAGS "${CMAKE_CPP_FLAGS} -I${BREW_PREFIX}/opt/libomp/include")
-  set(OpenMP_C_INCLUDE_DIR "${BREW_PREFIX}/opt/libomp/include")
-  set(OpenMP_CXX_INCLUDE_DIR "${BREW_PREFIX}/opt/libomp/include")
+  # $(brew --prefix libomp)/lib . This fix should work accross all platforms.
+  # find_package(OpenMP) can be guided with OpenMP_<lang>_INCLUDE_DIR.
+  set(CMAKE_CPP_FLAGS "${CMAKE_CPP_FLAGS} -I${LIBOMP_BREW_PREFIX}/include")
+  set(OpenMP_C_INCLUDE_DIR "${LIBOMP_BREW_PREFIX}/include")
+  set(OpenMP_CXX_INCLUDE_DIR "${LIBOMP_BREW_PREFIX}/include")
 endif(APPLE)
 
 # Check if we have a compatible openmp compiler

--- a/cmake/UseBioDynaMo.cmake.in
+++ b/cmake/UseBioDynaMo.cmake.in
@@ -162,6 +162,19 @@ else(MPI_FOUND)
   calling cmake. The OpenMPI library is required in order to successfully use BioDynaMo." )
 endif(MPI_FOUND)
 
+if(APPLE)
+  find_program(BREW_BIN brew)
+  execute_process(COMMAND ${BREW_BIN} --prefix
+                      OUTPUT_VARIABLE BREW_PREFIX
+                      OUTPUT_STRIP_TRAILING_WHITESPACE)
+  # After migrating to libomp 15.0.3, libomp does no longer symlink into 
+  # $(brew --prefix)/opt/lib/libomp.dylib. Instead, it is located in 
+  # $(brew --prefix)/opt/libomp/.. . This fix should work accross all platforms.
+  # find_package(OpenMP) can be guieded with OpenMP_<lang>_INCLUDE_DIR.
+  set(OpenMP_C_INCLUDE_DIR "${BREW_PREFIX}/opt/libomp/include")
+  set(OpenMP_CXX_INCLUDE_DIR "${BREW_PREFIX}/opt/libomp/include")
+endif(APPLE)
+
 find_package(OpenMP REQUIRED)
 
 if (OpenMP_CXX_FOUND)

--- a/cmake/env/thisbdm.fish
+++ b/cmake/env/thisbdm.fish
@@ -152,6 +152,20 @@ function source_thisbdm
         end
     end
 
+
+    # If we run on macOS, we add the following exports for libomp support
+    if test (uname) = 'Darwin'
+        set BREWPREFIX (brew --prefix); or return 1
+        if test -n "$CPPFLAGS"
+          _drop_from_var CPPFLAGS "-I$BREWPREFIX/opt/libomp/include"
+        end
+        if test -n "$LDFLAGS"
+          _drop_from_var LDFLAGS "-L$BREWPREFIX/opt/libomp/lib"
+        end
+        set -gx CPPFLAGS "-I$BREWPREFIX/opt/libomp/include $CPPFLAGS"
+        set -gx LDFLAGS "-L$BREWPREFIX/opt/libomp/lib $LDFLAGS"
+    end
+
     # paraview versions might be different between OSes
     set -l bdm_pv_version '5.9'
     if test (uname) = 'Darwin'

--- a/cmake/env/thisbdm.sh
+++ b/cmake/env/thisbdm.sh
@@ -232,6 +232,13 @@ _source_thisbdm()
     fi
   fi    
 
+  # If we run on macOS, we add the following exports
+  if [ "$(uname)" = "Darwin" ]; then
+    BREWPREFIX=$(brew --prefix)
+    export CPPFLAGS="-I$BREWPREFIX/opt/libomp/include"
+    export LDFLAGS="-L$BREWPREFIX/opt/libomp/lib"
+  fi
+
   # paraview versions might be different between OSes
   local bdm_pv_version='5.9'
   if [ "$(uname)" = 'Darwin' ]; then

--- a/cmake/env/thisbdm.sh
+++ b/cmake/env/thisbdm.sh
@@ -55,7 +55,9 @@ _drop_bdm_from_path()
   _newpath=$(echo "$p" | sed -e "s;:${drop}:;:;g"\
                              -e "s;:${drop}\$;;g"\
                              -e "s;^${drop}:;;g" \
-                             -e "s;^${drop}\$;;g")
+                             -e "s;^${drop}\$;;g"\
+                             -e "s; ${drop}\$;;g"\
+                             -e "s;^${drop} ;;g")
 }
 
 _bdm_define_command()
@@ -232,11 +234,19 @@ _source_thisbdm()
     fi
   fi    
 
-  # If we run on macOS, we add the following exports
+  # If we run on macOS, we add the following exports for libomp support
   if [ "$(uname)" = "Darwin" ]; then
     BREWPREFIX=$(brew --prefix)
-    export CPPFLAGS="-I$BREWPREFIX/opt/libomp/include"
-    export LDFLAGS="-L$BREWPREFIX/opt/libomp/lib"
+    if [ -n "${CPPFLAGS}" ]; then
+      _drop_bdm_from_path "$CPPFLAGS" "-I$BREWPREFIX/opt/libomp/include"
+      CPPFLAGS=$_newpath
+    fi
+    if [ -n "${LDFLAGS}" ]; then
+      _drop_bdm_from_path "$LDFLAGS" "-L$BREWPREFIX/opt/libomp/lib"
+      LDFLAGS=$_newpath
+    fi
+    export CPPFLAGS="-I$BREWPREFIX/opt/libomp/include $CPPFLAGS"
+    export LDFLAGS="-L$BREWPREFIX/opt/libomp/lib $LDFLAGS"
   fi
 
   # paraview versions might be different between OSes


### PR DESCRIPTION
Since OpenMP was updated to version 15.0.3 on MacOS, CMake was unable to locate it. This PR fixes the issue.