### PR TITLE
Make LAPACK and BLAS libraries available to user code

### DIFF
--- a/cmake/UseBioDynaMo.cmake.in
+++ b/cmake/UseBioDynaMo.cmake.in
@@ -349,7 +349,6 @@ set(BDM_REQUIRED_LIBRARIES ${BDM_REQUIRED_LIBRARIES} biodynamo ${ROOT_LIBRARIES}
 include_directories("$ENV{BDMSYS}/include")
 # armadillo is added as a subdirectory in optimlib
 include_directories("$ENV{BDMSYS}/include/optim")
-MESSAGE(DEBUG "This is ENV{BDMSYS} $ENV{BDMSYS}")
 link_directories("$ENV{BDMSYS}/lib")
 
 # -------------------- Instructions for GoogleTest -----------------------------

--- a/cmake/UseBioDynaMo.cmake.in
+++ b/cmake/UseBioDynaMo.cmake.in
@@ -271,6 +271,27 @@ else()
     include(CppStyleGuideChecks)
 endif()
 
+# If not set, sgemm_ is not found on macos
+if(APPLE)
+  set(BLA_VENDOR Apple)
+else()
+  set(BLA_VENDOR Generic)
+endif()
+
+find_package(BLAS)
+if (NOT BLAS_FOUND)
+    message(WARNING "BLAS not found.")
+else()
+  set(BDM_REQUIRED_LIBRARIES ${BDM_REQUIRED_LIBRARIES} ${BLAS_LIBRARIES})
+endif()
+
+find_package(LAPACK)
+if (NOT LAPACK_FOUND)
+    message(WARNING "LAPACK not found.")
+else()
+  set(BDM_REQUIRED_LIBRARIES ${BDM_REQUIRED_LIBRARIES} ${LAPACK_LIBRARIES})
+endif()
+
 # -------------------- set default build type and compiler flags ---------------
 if(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release)
@@ -328,6 +349,7 @@ set(BDM_REQUIRED_LIBRARIES ${BDM_REQUIRED_LIBRARIES} biodynamo ${ROOT_LIBRARIES}
 include_directories("$ENV{BDMSYS}/include")
 # armadillo is added as a subdirectory in optimlib
 include_directories("$ENV{BDMSYS}/include/optim")
+MESSAGE(DEBUG "This is ENV{BDMSYS} $ENV{BDMSYS}")
 link_directories("$ENV{BDMSYS}/lib")
 
 # -------------------- Instructions for GoogleTest -----------------------------


### PR DESCRIPTION
Make LAPACK and BLAS libraries available when using BioDynaMo. Both are already used when building BioDynaMo for the multi-simulation runtime.