### PR TITLE
Add print info member function to `DiffusionGrid`

### DIFF
--- a/src/core/diffusion/diffusion_grid.h
+++ b/src/core/diffusion/diffusion_grid.h
@@ -207,6 +207,17 @@ class DiffusionGrid : public ScalarField {
             dc_[4] == 0 && dc_[5] == 0 && dc_[6] == 0);
   }
 
+  /// Print information about the Diffusion Grid
+  void PrintInfo(std::ostream& out = std::cout);
+
+  /// Print the information after initialization
+  void PrintInfoWithInitialization() {
+    print_info_with_initialization_ = true;
+  };
+
+  /// Returns if the gird has been initialized
+  bool IsInitialized() const { return initialized_; }
+
  private:
   friend class RungeKuttaGrid;
   friend class EulerGrid;
@@ -270,6 +281,11 @@ class DiffusionGrid : public ScalarField {
       {};  //!
   // Turn to true after gradient initialization
   bool init_gradient_ = false;
+  /// Flag to indicate if the grid is initialized
+  bool initialized_ = false;
+  /// Flag to indicate if we want to print information about the grid after
+  /// initialization
+  bool print_info_with_initialization_ = false;
 
   BDM_CLASS_DEF_OVERRIDE(DiffusionGrid, 1);
 };

--- a/src/core/simulation.cc
+++ b/src/core/simulation.cc
@@ -155,7 +155,7 @@ std::ostream& operator<<(std::ostream& os, Simulation& sim) {
      << sim.scheduler_->GetSimulatedSteps() << std::endl;
   os << "Number of agents\t\t: " << sim.rm_->GetNumAgents() << std::endl;
 
-  sim.rm_->ForEachDiffusionGrid([&](auto* dgrid) { dgrid->PrintInfo(os); });
+  sim.rm_->ForEachDiffusionGrid([&os](auto* dgrid) { dgrid->PrintInfo(os); });
 
   os << "Output directory\t\t: " << sim.GetOutputDir() << std::endl;
   os << "  size\t\t\t\t: "

--- a/src/core/simulation.cc
+++ b/src/core/simulation.cc
@@ -135,18 +135,6 @@ void Simulation::Restore(Simulation&& restored) {
 }
 
 std::ostream& operator<<(std::ostream& os, Simulation& sim) {
-  std::vector<std::string> dgrid_names;
-  std::vector<size_t> dgrid_resolutions;
-  std::vector<std::array<int32_t, 3>> dgrid_dimensions;
-  std::vector<uint64_t> dgrid_voxels;
-
-  sim.rm_->ForEachDiffusionGrid([&](auto* dgrid) {
-    dgrid_names.push_back(dgrid->GetContinuumName());
-    dgrid_resolutions.push_back(dgrid->GetResolution());
-    dgrid_dimensions.push_back(dgrid->GetGridSize());
-    dgrid_voxels.push_back(dgrid->GetNumBoxes());
-  });
-
   os << std::endl;
 
   os << "***********************************************" << std::endl;
@@ -167,19 +155,7 @@ std::ostream& operator<<(std::ostream& os, Simulation& sim) {
      << sim.scheduler_->GetSimulatedSteps() << std::endl;
   os << "Number of agents\t\t: " << sim.rm_->GetNumAgents() << std::endl;
 
-  if (dgrid_names.size() != 0) {
-    os << "Diffusion grids" << std::endl;
-    for (size_t i = 0; i < dgrid_names.size(); ++i) {
-      os << "  " << dgrid_names[i] << ":" << std::endl;
-      auto& dim = dgrid_dimensions[i];
-      os << "\t"
-         << "Resolution\t\t: " << dgrid_resolutions[i] << std::endl;
-      os << "\t"
-         << "Size\t\t\t: " << dim[0] << " x " << dim[1] << " x " << dim[2]
-         << std::endl
-         << "\tVoxels\t\t\t: " << dgrid_voxels[i] << std::endl;
-    }
-  }
+  sim.rm_->ForEachDiffusionGrid([&](auto* dgrid) { dgrid->PrintInfo(os); });
 
   os << "Output directory\t\t: " << sim.GetOutputDir() << std::endl;
   os << "  size\t\t\t\t: "


### PR DESCRIPTION
Add a function `void DiffusionGrid::PrintInfo(std::ostream)` that prints the configuration of the diffusion grid. Sample output:
```
DiffusionGrid: Nutrients
    D          = 0.833333
    decay      = 1e-05
    dx         = 12.6582
    max(dt)    <= 32.0461
    bounds     : 0 < c < 1
    domain     : [-500, 500] x [-500, 500] x [-500, 500]
    resolution : 80 x 80 x 80
    num boxes  : 512000
```