### PR TITLE
Demo4paraview

### DIFF
--- a/demo/custom_paraview/CMakeLists.txt
+++ b/demo/custom_paraview/CMakeLists.txt
@@ -1,0 +1,29 @@
+# -----------------------------------------------------------------------------
+#
+# Copyright (C) 2021 CERN & University of Surrey for the benefit of the
+# BioDynaMo collaboration. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+#
+# See the LICENSE file distributed with this work for details.
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
+#
+# -----------------------------------------------------------------------------
+
+cmake_minimum_required(VERSION 3.2.0)
+
+project(custom_paraview)
+
+find_package(BioDynaMo REQUIRED)
+include("${BDM_USE_FILE}")
+include_directories("src")
+
+file(GLOB_RECURSE HEADERS src/*.h)
+file(GLOB_RECURSE SOURCES src/*.cc)
+
+bdm_add_executable(custom_paraview
+                   HEADERS "${HEADERS}"
+                   SOURCES "${SOURCES}"
+                   LIBRARIES "${BDM_REQUIRED_LIBRARIES}")

--- a/demo/custom_paraview/src/custom_paraview.cc
+++ b/demo/custom_paraview/src/custom_paraview.cc
@@ -1,0 +1,16 @@
+// -----------------------------------------------------------------------------
+//
+// Copyright (C) 2021 CERN & University of Surrey for the benefit of the
+// BioDynaMo collaboration. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// See the LICENSE file distributed with this work for details.
+// See the NOTICE file distributed with this work for additional information
+// regarding copyright ownership.
+//
+// -----------------------------------------------------------------------------
+#include "custom_paraview.h"
+
+int main(int argc, const char** argv) { return bdm::Simulate(argc, argv); }

--- a/demo/custom_paraview/src/custom_paraview.h
+++ b/demo/custom_paraview/src/custom_paraview.h
@@ -108,8 +108,62 @@ inline void cells_4paraview(ResourceManager* rm, int time =0) {
   // completed exporting to the VTU file
 }
 
-inline void diffusiongrid_4paraview(ResourceManager* rm, int time =0) {
+inline void grid_4paraview(ResourceManager* rm, int time =0) {
+  //
+  const unsigned int n_VTK_points = Grid_XYZ.size();
+  //
+  const unsigned int n_VTK_cells = 1;
 
+  // create the VTU file to store BioDynaMo simulation data
+  std::ofstream fout("output/custom_paraview/grid_4paraview."+std::to_string(time)+".vtu");
+  // write the header of the XML-structured file
+  fout << "<?xml version=\"1.0\"?>" << std::endl;
+  fout << "<VTKFile type=\"UnstructuredGrid\" version=\"0.1\" byte_order=\"LittleEndian\">" << std::endl;
+  fout << "  <UnstructuredGrid>" << std::endl;
+  fout << "    <Piece NumberOfPoints=\"" << n_VTK_points << "\" NumberOfCells=\"" << n_VTK_cells << "\">" << std::endl;
+  // output the coordinates of all grid points
+  fout << "      <Points>" << std::endl;
+  fout << "        <DataArray type=\"Float64\" NumberOfComponents=\"3\" format=\"ascii\">" << std::endl;
+  for (auto const& xyz : Grid_XYZ)
+      fout << ' ' << xyz[0]
+           << ' ' << xyz[1]
+           << ' ' << xyz[2];
+  fout << std::endl;
+  fout << "        </DataArray>" << std::endl;
+  fout << "      </Points>" << std::endl;
+  // start -- output BioDynaMo simulation data for all grids
+  fout << "      <PointData>" << std::endl;
+  for (auto const& m : Grid_ID2Name)
+    {
+      // access the grid for this substance
+      auto* dg = rm->GetDiffusionGrid(m.first);
+      //
+      fout << "        <DataArray type=\"Float64\" Name=\""+m.second+"\" NumberOfComponents=\"1\" format=\"ascii\">" << std::endl;
+      for (auto const& xyz : Grid_XYZ)
+        fout << ' ' << dg->GetValue(xyz);
+      fout << std::endl;
+      fout << "        </DataArray>" << std::endl;
+    }
+  fout << "        </PointData>" << std::endl;
+  // end -- output BioDynaMo simulation data for all grids
+  // start -- output all grid points as a "VTK_POLY_VERTEX" VTK cell structure
+  fout << "      <Cells>" << std::endl;
+  fout << "        <DataArray type=\"Int32\" Name=\"offsets\" NumberOfComponents=\"1\" format=\"ascii\">" << std::endl;
+  fout << ' ' << n_VTK_points << std::endl;
+  fout << "        </DataArray>" << std::endl;
+  fout << "        <DataArray type=\"Int32\" Name=\"connectivity\" NumberOfComponents=\"1\" format=\"ascii\">" << std::endl;
+  for (unsigned int p=0; p<n_VTK_points; p++) fout << ' ' << p;
+  fout << std::endl;
+  fout << "        </DataArray>" << std::endl;
+  fout << "        <DataArray type=\"Int32\" Name=\"types\" NumberOfComponents=\"1\" format=\"ascii\">" << std::endl;
+  fout << ' ' << 2 << std::endl;
+  fout << "        </DataArray>" << std::endl;
+  fout << "      </Cells>" << std::endl;
+  // end -- output all grid points as a "VTK_POLY_VERTEX" VTK cell structure
+  fout << "    </Piece>" << std::endl;
+  fout << "  </UnstructuredGrid>" << std::endl;
+  fout << "</VTKFile>" << std::endl;
+  // completed exporting to the VTU file
 }
 
 inline int Simulate(int argc, const char** argv) {
@@ -148,6 +202,20 @@ inline int Simulate(int argc, const char** argv) {
   ModelInitializer::DefineSubstance(0, Grid_ID2Name[0], 0., 0., N);
   ModelInitializer::DefineSubstance(1, Grid_ID2Name[1], 0.1, 0., N);
   ModelInitializer::CreateAgentsRandom(-10.0, +10.0, 2000, GenerateCells);
+
+  simulation.GetScheduler()->Simulate(1);
+
+  // output all agent and grid related data
+  // in VTU-formatted files for Paraview
+  cells_4paraview(rm, 1);
+  grid_4paraview(rm, 1);
+
+  simulation.GetScheduler()->Simulate(99);
+
+  // output all agent and grid related data
+  // in VTU-formatted files for Paraview
+  cells_4paraview(rm, 100);
+  grid_4paraview(rm, 100);
 
   std::cout << "Simulation completed successfully!" << std::endl;
   return 0;

--- a/demo/custom_paraview/src/custom_paraview.h
+++ b/demo/custom_paraview/src/custom_paraview.h
@@ -16,6 +16,7 @@
 
 #include "biodynamo.h"
 
+static std::map<size_t, std::string> dg__ID2Name;
 namespace bdm {
 
 inline void cells_4paraview(ResourceManager* rm, int time =0) {
@@ -89,6 +90,10 @@ inline void cells_4paraview(ResourceManager* rm, int time =0) {
   // completed exporting to the VTU file
 }
 
+inline void diffusiongrid_4paraview(ResourceManager* rm, int time =0) {
+
+}
+
 inline int Simulate(int argc, const char** argv) {
   Simulation simulation(argc, argv);
 
@@ -109,6 +114,16 @@ inline int Simulate(int argc, const char** argv) {
   // output all agent-data in a VTU-formatted
   // file for Paraview
   cells_4paraview(rm);
+
+  // create 2 biochemical cues
+  dg__ID2Name[0] = "O2";
+  dg__ID2Name[1] = "GF";
+  ModelInitializer::DefineSubstance(0, dg__ID2Name[0], 0.0, 0.0);
+  ModelInitializer::DefineSubstance(1, dg__ID2Name[1], 0.0, 0.0);
+
+  // output all diffusion grid-data in a VTU-formatted
+  // file for Paraview
+  diffusiongrid_4paraview(rm);
 
   std::cout << "Simulation completed successfully!" << std::endl;
   return 0;

--- a/demo/custom_paraview/src/custom_paraview.h
+++ b/demo/custom_paraview/src/custom_paraview.h
@@ -17,7 +17,25 @@
 #include "biodynamo.h"
 
 static std::map<size_t, std::string> dg__ID2Name;
+static std::vector<bdm::Double3> dg__XYZ;
+
 namespace bdm {
+
+inline void set_global_parameters(Param* p)
+{
+  // user-defined BioDynaMo parameters adopted for the simulation
+  p->simulation_time_step = 1.0;
+  p->bound_space = Param::BoundSpaceMode::kClosed;
+  p->min_bound = -10.0;
+  p->max_bound = +10.0;
+  //p->detect_static_agents = true;
+  //p->calculate_gradients = false;
+  //p->diffusion_method = "euler";
+  //p->diffusion_boundary_condition = "open";
+  p->show_simulation_step = false;
+  p->export_visualization = false;
+  p->remove_output_dir_contents = false;
+}
 
 inline void cells_4paraview(ResourceManager* rm, int time =0) {
   // iterate to calculate the total number of cells (agents)
@@ -95,7 +113,7 @@ inline void diffusiongrid_4paraview(ResourceManager* rm, int time =0) {
 }
 
 inline int Simulate(int argc, const char** argv) {
-  Simulation simulation(argc, argv);
+  Simulation simulation("custom_paraview", set_global_parameters);
 
   // access the simulation resource manager
   auto* rm = simulation.GetResourceManager();

--- a/demo/custom_paraview/src/custom_paraview.h
+++ b/demo/custom_paraview/src/custom_paraview.h
@@ -1,0 +1,119 @@
+// -----------------------------------------------------------------------------
+//
+// Copyright (C) 2021 CERN & University of Surrey for the benefit of the
+// BioDynaMo collaboration. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// See the LICENSE file distributed with this work for details.
+// See the NOTICE file distributed with this work for additional information
+// regarding copyright ownership.
+//
+// -----------------------------------------------------------------------------
+#ifndef CUSTOM_PARAVIEW_H_
+#define CUSTOM_PARAVIEW_H_
+
+#include "biodynamo.h"
+
+namespace bdm {
+
+inline void cells_4paraview(ResourceManager* rm, int time =0) {
+  // iterate to calculate the total number of cells (agents)
+  // in the simulation, they will be output as points
+  unsigned int n_VTK_points = 0;
+  rm->ForEachAgent([&] (Agent* a) {
+    if (auto* c = dynamic_cast<Cell*>(a))
+      ++n_VTK_points;
+  });
+  // all cells (agents) will be considered as a cluster of
+  // points, denoted as one poly-vertex VTK cell structure
+  const unsigned int n_VTK_cells = 1;
+
+  // create the VTU file to store BioDynaMo simulation data
+  std::ofstream fout("output/custom_paraview/cells_4paraview."+std::to_string(time)+".vtu");
+  // write the header of the XML-structured file
+  fout << "<?xml version=\"1.0\"?>" << std::endl;
+  fout << "<VTKFile type=\"UnstructuredGrid\" version=\"0.1\" byte_order=\"LittleEndian\">" << std::endl;
+  fout << "  <UnstructuredGrid>" << std::endl;
+  fout << "    <Piece NumberOfPoints=\"" << n_VTK_points << "\" NumberOfCells=\"" << n_VTK_cells << "\">" << std::endl;
+  // output the coordinates of all cells
+  fout << "      <Points>" << std::endl;
+  fout << "        <DataArray type=\"Float64\" NumberOfComponents=\"3\" format=\"ascii\">" << std::endl;
+  rm->ForEachAgent([&] (Agent* a) {
+    if (auto* c = dynamic_cast<Cell*>(a))
+      fout << ' ' << c->GetPosition()[0]
+           << ' ' << c->GetPosition()[1]
+           << ' ' << c->GetPosition()[2];
+  });
+  fout << std::endl;
+  fout << "        </DataArray>" << std::endl;
+  fout << "      </Points>" << std::endl;
+  // start -- output BioDynaMo simulation data for all cells
+  fout << "      <PointData>" << std::endl;
+  // output the diameter of all cells
+  fout << "        <DataArray type=\"Float64\" Name=\"diameter\" NumberOfComponents=\"1\" format=\"ascii\">" << std::endl;
+  rm->ForEachAgent([&] (Agent* a) {
+    if (auto* c = dynamic_cast<Cell*>(a))
+      fout << ' ' << c->GetDiameter();
+  });
+  fout << std::endl;
+  fout << "        </DataArray>" << std::endl;
+  // output the volume of all cells
+  fout << "        <DataArray type=\"Float64\" Name=\"volume\" NumberOfComponents=\"1\" format=\"ascii\">" << std::endl;
+  rm->ForEachAgent([&] (Agent* a) {
+    if (auto* c = dynamic_cast<Cell*>(a))
+      fout << ' ' << c->GetVolume();
+  });
+  fout << std::endl;
+  fout << "        </DataArray>" << std::endl;
+  fout << "      </PointData>" << std::endl;
+  // end -- output BioDynaMo simulation data for all cells
+  // start -- output all agents as a "VTK_POLY_VERTEX" VTK cell structure
+  fout << "      <Cells>" << std::endl;
+  fout << "        <DataArray type=\"Int32\" Name=\"offsets\" NumberOfComponents=\"1\" format=\"ascii\">" << std::endl;
+  fout << ' ' << n_VTK_points << std::endl;
+  fout << "        </DataArray>" << std::endl;
+  fout << "        <DataArray type=\"Int32\" Name=\"connectivity\" NumberOfComponents=\"1\" format=\"ascii\">" << std::endl;
+  for (unsigned int p=0; p<n_VTK_points; p++) fout << ' ' << p;
+  fout << std::endl;
+  fout << "        </DataArray>" << std::endl;
+  fout << "        <DataArray type=\"Int32\" Name=\"types\" NumberOfComponents=\"1\" format=\"ascii\">" << std::endl;
+  fout << ' ' << 2 << std::endl;
+  fout << "        </DataArray>" << std::endl;
+  fout << "      </Cells>" << std::endl;
+  // end -- output all agents as a "VTK_POLY_VERTEX" VTK cell structure
+  fout << "    </Piece>" << std::endl;
+  fout << "  </UnstructuredGrid>" << std::endl;
+  fout << "</VTKFile>" << std::endl;
+  // completed exporting to the VTU file
+}
+
+inline int Simulate(int argc, const char** argv) {
+  Simulation simulation(argc, argv);
+
+  // access the simulation resource manager
+  auto* rm = simulation.GetResourceManager();
+
+  // create 8 cells (agents) positioned at the
+  // vertices of a perfect hexagon
+  rm->AddAgent(new Cell({-1.0, -1.0, -1.0}));
+  rm->AddAgent(new Cell({+1.0, -1.0, -1.0}));
+  rm->AddAgent(new Cell({+1.0, +1.0, -1.0}));
+  rm->AddAgent(new Cell({-1.0, +1.0, -1.0}));
+  rm->AddAgent(new Cell({-1.0, -1.0, +1.0}));
+  rm->AddAgent(new Cell({+1.0, -1.0, +1.0}));
+  rm->AddAgent(new Cell({+1.0, +1.0, +1.0}));
+  rm->AddAgent(new Cell({-1.0, +1.0, +1.0}));
+
+  // output all agent-data in a VTU-formatted
+  // file for Paraview
+  cells_4paraview(rm);
+
+  std::cout << "Simulation completed successfully!" << std::endl;
+  return 0;
+}
+
+}  // namespace bdm
+
+#endif  // CUSTOM_PARAVIEW_H_


### PR DESCRIPTION
**Purpose:** 
Demonstrate in new users how to a VTU formatted file for Paraview is structured to output cell (agents) and grid (continuum) data. To understand the driver function of this demo, users are advised  to study the _diffusion_ demo first.

**Results:**
Successful execution of the demo, four VTU files are produced in the `output/custom_paraview` sub-folder that can be opened directly through Paraview. Files `cells_4paraview.*.vtu` (at two time steps) contain the results for all cells (agents) in the simulation, while files `grid_4paraview.*.vtu` (again at two time steps) contain the results for the two continuum (previously named diffusion grids) substances - in this example oxygen (`O2`) and some growth factor (`GF`).
