### PR TITLE
Replace `rm->AddAgent` with `ctxt->AddAgent` in demos

### DIFF
--- a/demo/diffusion/src/diffusion.h
+++ b/demo/diffusion/src/diffusion.h
@@ -49,7 +49,7 @@ inline int Simulate(int argc, const char** argv) {
   // The cell responsible for secretion
   auto* secreting_cell = new Cell({50, 50, 50});
   secreting_cell->AddBehavior(new Secretion("Kalium", 4));
-  simulation.GetResourceManager()->AddAgent(secreting_cell);
+  simulation.GetExecutionContext()->AddAgent(secreting_cell);
 
   // Run simulation for N timesteps
   simulation.GetScheduler()->Simulate(300);

--- a/demo/flocking/src/flocking.cc
+++ b/demo/flocking/src/flocking.cc
@@ -29,7 +29,7 @@ int Simulate(int argc, const char** argv) {
   // Set references
   Param::RegisterParamGroup(new SimParam());
   Simulation simulation(argc, argv);
-  auto* rm = simulation.GetResourceManager();
+  auto* ctxt = simulation.GetExecutionContext();
   auto* param = simulation.GetParam();
   auto* sparam = param->Get<SimParam>();
   auto* scheduler = simulation.GetScheduler();
@@ -53,7 +53,7 @@ int Simulate(int argc, const char** argv) {
         new RandomPerturbation(sparam->random_perturbation_strength));
     boid->InitializeMembers();
 
-    rm->AddAgent(boid);
+    ctxt->AddAgent(boid);
   }
 
   // ---------------------------------------------------------------------------

--- a/demo/makefile_project/src/makefile_project.h
+++ b/demo/makefile_project/src/makefile_project.h
@@ -25,7 +25,7 @@ inline int Simulate(int argc, const char** argv) {
   // Define initial model - in this example: single cell at origin
   Cell* cell = new Cell({0, 0, 0});
   cell->SetDiameter(30);
-  simulation.GetResourceManager()->AddAgent(cell);
+  simulation.GetExecutionContext()->AddAgent(cell);
 
   // Run simulation for one timestep
   simulation.GetScheduler()->Simulate(1);

--- a/demo/monolayer_growth/src/monolayer_growth.h
+++ b/demo/monolayer_growth/src/monolayer_growth.h
@@ -52,9 +52,9 @@ inline int Simulate(int argc, const char** argv) {
   // Create a new simulation
   Simulation simulation(argc, argv, set_param);
   SetupResultCollection(&simulation);
-  auto* rm = simulation.GetResourceManager();   // Get the resource manager
-  auto* scheduler = simulation.GetScheduler();  // Get the scheduler
-  auto* param = simulation.GetParam();          // Get the parameters
+  auto* ctxt = simulation.GetExecutionContext();  // Get the execution context
+  auto* scheduler = simulation.GetScheduler();    // Get the scheduler
+  auto* param = simulation.GetParam();            // Get the parameters
   const auto* sparam = param->Get<SimParam>();  // Get the simulation parameters
 
   real_t x_coord = sparam->pos0;
@@ -72,7 +72,7 @@ inline int Simulate(int argc, const char** argv) {
       cell->SetCycle(CellState::kG1);
       cell->SetCanDivide(true);
       cell->AddBehavior(new GrowthAndCellCycle());
-      rm->AddAgent(cell);  // put the created cell in our cells structure
+      ctxt->AddAgent(cell);  // put the created cell in our cells structure
       y_coord += sparam->cell_diam;
     }
     x_coord += sparam->cell_diam;

--- a/demo/multiple_simulations/src/multiple_simulations.h
+++ b/demo/multiple_simulations/src/multiple_simulations.h
@@ -48,10 +48,10 @@ inline int Simulate(int argc, const char** argv) {
     sim->Activate();
 
     // Create initial model
-    auto* rm = sim->GetResourceManager();
+    auto* ctxt = sim->GetExecutionContext();
     Cell* cell = new Cell(30);
     cell->AddBehavior(new Divide());
-    rm->AddAgent(cell);
+    ctxt->AddAgent(cell);
   }
 
   // For each simulation simulate 5 timesteps

--- a/demo/pyramidal_cell/src/pyramidal_cell.h
+++ b/demo/pyramidal_cell/src/pyramidal_cell.h
@@ -131,7 +131,7 @@ struct BasalDendriteGrowth : public Behavior {
 inline void AddInitialNeuron(const Real3& position) {
   auto* soma = new neuroscience::NeuronSoma(position);
   soma->SetDiameter(10);
-  Simulation::GetActive()->GetResourceManager()->AddAgent(soma);
+  Simulation::GetActive()->GetExecutionContext()->AddAgent(soma);
 
   auto* apical_dendrite = soma->ExtendNewNeurite({0, 0, 1});
   auto* basal_dendrite1 = soma->ExtendNewNeurite({0, 0, -1});

--- a/demo/tumor_concept/src/tumor_concept.h
+++ b/demo/tumor_concept/src/tumor_concept.h
@@ -104,7 +104,7 @@ inline int Simulate(int argc, const char** argv) {
   };
 
   Simulation simulation(argc, argv, set_param);
-  auto* rm = simulation.GetResourceManager();
+  auto* ctxt = simulation.GetExecutionContext();
   auto* param = simulation.GetParam();
   auto* myrand = simulation.GetRandom();
 
@@ -125,7 +125,7 @@ inline int Simulate(int argc, const char** argv) {
     // will vary from 0 to 5. so 6 different layers depending on y_coord
     cell->SetCellColor(static_cast<int>((y_coord / param->max_bound * 6)));
 
-    rm->AddAgent(cell);  // put the created cell in our cells structure
+    ctxt->AddAgent(cell);  // put the created cell in our cells structure
   }
 
   // create a cancerous cell, containing the behavior Growth
@@ -134,7 +134,7 @@ inline int Simulate(int argc, const char** argv) {
   cell->SetCellColor(8);
   cell->SetCanDivide(true);
   cell->AddBehavior(new Growth());
-  rm->AddAgent(cell);  // put the created cell in our cells structure
+  ctxt->AddAgent(cell);  // put the created cell in our cells structure
 
   // Run simulation
   simulation.GetScheduler()->Simulate(500);

--- a/doc/user_guide/diffusion.md
+++ b/doc/user_guide/diffusion.md
@@ -76,7 +76,7 @@ attributes:
    // The cell responsible for secretion
   Cell secreting_cell({50, 50, 50});
   secreting_cell.AddBehavior(new Secretion("Kalium", 4));
-  simulation.GetResourceManager()->AddAgent(&secreting_cell);
+  simulation.GetExecutionContext()->AddAgent(&secreting_cell);
 ```
 
 The `construct` lambda defines the properties of each cell that we create. These can be

--- a/doc/user_guide/tumor_concept.md
+++ b/doc/user_guide/tumor_concept.md
@@ -70,7 +70,7 @@ Afterwards, we obtain a reference to a few important objects.
   * `Param` holds our simulation parameters.
 
 ```cpp
-auto* rm = simulation.GetResourceManager();
+auto* ctxt = simulation.GetExecutionContext();
 auto* random = simulation.GetRandom();
 auto* param = simulation.GetParam();
 ```
@@ -95,7 +95,7 @@ for (size_t i = 0; i < nb_of_cells; ++i) {
   // set cell parameters
   cell->SetDiameter(7.5);
 
-  rm->AddAgent(cell);  // put the created cell in our cells structure
+  ctxt->AddAgent(cell);  // put the created cell in our cells structure
 }
 ```
 
@@ -137,7 +137,7 @@ Of course, we need to create at least one new cell that contains our `Growth` be
 Cell* cell = new Cell({20, 50, 50});
 cell->SetDiameter(6);
 cell->AddBehavior(new Growth());
-rm->AddAgent(cell);  // put the created cell in our cells structure
+ctxt->AddAgent(cell);  // put the created cell in our cells structure
 ```
 
 Run running it using `biodynamo run`. This code is now able to create and simulate 2 400 normal cells and 1 cancerous cell that will grow and divide! Complete code can be found in `demo/tumor_concept`.

--- a/src/core/execution_context/execution_context.h
+++ b/src/core/execution_context/execution_context.h
@@ -79,6 +79,23 @@ class ExecutionContext {
                                const Real3& query_position,
                                real_t squared_radius) = 0;
 
+  /// @brief  Adds the agent to the simulation (threadsafe, takes ownership).
+  ///         Note that we avoid the use of smart pointers for the agents to
+  ///         avoid unnecessary overhead during construction of the agent
+  ///         (performance argument).
+  /// `usage example`:
+  /// \code
+  ///   auto* ctxt = Simulation::GetActive()->GetExecutionContext();
+  ///   ctxt->AddAgent(new Agent());
+  /// \endcode
+  /// or
+  /// \code
+  ///   auto* ctxt = Simulation::GetActive()->GetExecutionContext();
+  ///   auto* agent = new Agent();
+  ///   // modify agent
+  ///   ctxt->AddAgent(agent);
+  /// \endcode
+  /// @param new_agent The agent to be added to the simulation
   virtual void AddAgent(Agent* new_agent) = 0;
 
   virtual void RemoveAgent(const AgentUid& uid) = 0;

--- a/src/core/resource_manager.h
+++ b/src/core/resource_manager.h
@@ -387,9 +387,12 @@ class ResourceManager {
 
   void DebugNuma() const;
 
-  /// NB: This method is not thread-safe! This function might invalidate
-  /// agent references pointing into the ResourceManager. AgentPointer are
-  /// not affected.
+  /// @brief Add an agent to the ResourceManager (not thread-safe). This
+  /// function might invalidate agent references pointing into the
+  /// ResourceManager. AgentPointer are not affected. For adding agents to a
+  /// Simulation, use ExecutionContext::AddAgent.
+  /// @param agent Agent to be added
+  /// @param numa_node NUMA node to which the agent will be added (default: 0)
   void AddAgent(Agent* agent,  // NOLINT
                 typename AgentHandle::NumaNode_t numa_node = 0) {
     auto uid = agent->GetUid();


### PR DESCRIPTION
The call `rm->AddAgent` is not thread safe and users should typically use `ctxt->AddAgent`. With this PR, we change the demo code such that future uses will learn to use `ctxt->AddAgent`.