### PR TITLE
Enable double precision in OpenCL kernel when compatible GPU is found

### DIFF
--- a/src/core/gpu/gpu_helper.cc
+++ b/src/core/gpu/gpu_helper.cc
@@ -176,12 +176,11 @@ void GpuHelper::FindGpuDevicesOpenCL() {
           if (!d->getInfo<CL_DEVICE_AVAILABLE>())  // NOLINT
             continue;
 
-          if (!d->getInfo<CL_DEVICE_PREFERRED_VECTOR_WIDTH_DOUBLE>()) {
+          if (d->getInfo<CL_DEVICE_PREFERRED_VECTOR_WIDTH_DOUBLE>()) {
+            ocl_state->EnableSupportForDouble();
+          } else {
             ocl_state->DisableSupportForDouble();
           }
-
-          // The OpenCL extension available on this device
-          std::string ext = d->getInfo<CL_DEVICE_EXTENSIONS>();
 
           devices->push_back(*d);
         }
@@ -214,7 +213,9 @@ void GpuHelper::FindGpuDevicesOpenCL() {
       auto itr = std::find(ocl_state->GetFp64Support()->begin(),
                            ocl_state->GetFp64Support()->end(), true);
       if (itr == ocl_state->GetFp64Support()->end()) {
-        selected_gpu = 0;
+        Log::Fatal("FindGpuDevicesOpenCL",
+                   "No OpenCL compatible GPU's with double precision support found on this machine!");
+        return;
       } else {
         selected_gpu =
             std::distance(ocl_state->GetFp64Support()->begin(), itr);

--- a/src/core/gpu/gpu_helper.cc
+++ b/src/core/gpu/gpu_helper.cc
@@ -211,17 +211,19 @@ void GpuHelper::FindGpuDevicesOpenCL() {
     int selected_gpu = param->preferred_gpu;
     // If not specifically selected, we select the first GPU with double support
     if (selected_gpu < 0) {
-      auto itr = std::find(ocl_state->impl_->fp64_support_.begin(),
-                           ocl_state->impl_->fp64_support_.end(), true);
-      if (itr == vct.end()) {
+      auto itr = std::find(ocl_state->GetFp64Support()->begin(),
+                           ocl_state->GetFp64Support()->end(), true);
+      if (itr == ocl_state->GetFp64Support()->end()) {
         selected_gpu = 0;
       } else {
         selected_gpu =
-            std::distance(ocl_state->impl_->fp64_support_..begin(), itr);
+            std::distance(ocl_state->GetFp64Support()->begin(), itr);
       }
     }
     Log::Info("", "Selected GPU [", selected_gpu,
               "]: ", (*devices)[selected_gpu].getInfo<CL_DEVICE_NAME>());
+
+    ocl_state->SelectGpu(selected_gpu);
 
     // Create command queue for that GPU
     cl_int queue_err;

--- a/src/core/gpu/gpu_helper.cc
+++ b/src/core/gpu/gpu_helper.cc
@@ -209,6 +209,17 @@ void GpuHelper::FindGpuDevicesOpenCL() {
     }
 
     int selected_gpu = param->preferred_gpu;
+    // If not specifically selected, we select the first GPU with double support
+    if (selected_gpu < 0) {
+      auto itr = std::find(ocl_state->impl_->fp64_support_.begin(),
+                           ocl_state->impl_->fp64_support_.end(), true);
+      if (itr == vct.end()) {
+        selected_gpu = 0;
+      } else {
+        selected_gpu =
+            std::distance(ocl_state->impl_->fp64_support_..begin(), itr);
+      }
+    }
     Log::Info("", "Selected GPU [", selected_gpu,
               "]: ", (*devices)[selected_gpu].getInfo<CL_DEVICE_NAME>());
 

--- a/src/core/gpu/gpu_helper.cc
+++ b/src/core/gpu/gpu_helper.cc
@@ -214,11 +214,11 @@ void GpuHelper::FindGpuDevicesOpenCL() {
                            ocl_state->GetFp64Support()->end(), true);
       if (itr == ocl_state->GetFp64Support()->end()) {
         Log::Fatal("FindGpuDevicesOpenCL",
-                   "No OpenCL compatible GPU's with double precision support found on this machine!");
+                   "No OpenCL compatible GPU's with double precision support "
+                   "found on this machine!");
         return;
       } else {
-        selected_gpu =
-            std::distance(ocl_state->GetFp64Support()->begin(), itr);
+        selected_gpu = std::distance(ocl_state->GetFp64Support()->begin(), itr);
       }
     }
     Log::Info("", "Selected GPU [", selected_gpu,

--- a/src/core/gpu/opencl_state.cc
+++ b/src/core/gpu/opencl_state.cc
@@ -63,9 +63,7 @@ std::vector<cl::Device>* OpenCLState::GetOpenCLDeviceList() {
   return &impl_->opencl_devices_;
 }
 
-void OpenCLState::SelectGpu(int gpu) {
-  impl_->selected_gpu_ = gpu;
-}
+void OpenCLState::SelectGpu(int gpu) { impl_->selected_gpu_ = gpu; }
 
 std::vector<bool>* OpenCLState::GetFp64Support() {
   return &impl_->fp64_support_;

--- a/src/core/gpu/opencl_state.cc
+++ b/src/core/gpu/opencl_state.cc
@@ -40,7 +40,7 @@ struct OpenCLState::OpenCLImpl {
   // Currently only support for one GPU device
   std::vector<cl::Device> opencl_devices_;
   std::vector<cl::Program> opencl_programs_;
-  bool fp64_support_ = true;
+  std::vector<bool> fp64_support_;
 };
 
 OpenCLState::OpenCLState() {
@@ -67,9 +67,15 @@ std::vector<cl::Program>* OpenCLState::GetOpenCLProgramList() {
   return &impl_->opencl_programs_;
 }
 
-bool OpenCLState::HasSupportForDouble() { return impl_->fp64_support_; }
+// Returns if the `Param::preferred_gpu` has support for double
+bool OpenCLState::HasSupportForDouble() {
+  int selected_gpu = Simulation::GetActive()->GetParam()->preferred_gpu;
+  return impl_->fp64_support_[selected_gpu];
+}
 
-void OpenCLState::DisableSupportForDouble() { impl_->fp64_support_ = false; }
+void OpenCLState::DisableSupportForDouble() {
+  impl_->fp64_support_.push_back(false);
+}
 
 const char* OpenCLState::GetErrorString(int error) {
   switch (error) {

--- a/src/core/gpu/opencl_state.cc
+++ b/src/core/gpu/opencl_state.cc
@@ -41,6 +41,7 @@ struct OpenCLState::OpenCLImpl {
   std::vector<cl::Device> opencl_devices_;
   std::vector<cl::Program> opencl_programs_;
   std::vector<bool> fp64_support_;
+  int selected_gpu_ = -1;
 };
 
 OpenCLState::OpenCLState() {
@@ -62,6 +63,14 @@ std::vector<cl::Device>* OpenCLState::GetOpenCLDeviceList() {
   return &impl_->opencl_devices_;
 }
 
+void OpenCLState::SelectGpu(int gpu) {
+  impl_->selected_gpu_ = gpu;
+}
+
+std::vector<bool>* OpenCLState::GetFp64Support() {
+  return &impl_->fp64_support_;
+}
+
 /// Returns the OpenCL program (kernel) list
 std::vector<cl::Program>* OpenCLState::GetOpenCLProgramList() {
   return &impl_->opencl_programs_;
@@ -69,8 +78,7 @@ std::vector<cl::Program>* OpenCLState::GetOpenCLProgramList() {
 
 // Returns if the `Param::preferred_gpu` has support for double
 bool OpenCLState::HasSupportForDouble() {
-  int selected_gpu = Simulation::GetActive()->GetParam()->preferred_gpu;
-  return impl_->fp64_support_[selected_gpu];
+  return impl_->fp64_support_[impl_->selected_gpu_];
 }
 
 void OpenCLState::DisableSupportForDouble() {

--- a/src/core/gpu/opencl_state.cc
+++ b/src/core/gpu/opencl_state.cc
@@ -85,6 +85,10 @@ void OpenCLState::DisableSupportForDouble() {
   impl_->fp64_support_.push_back(false);
 }
 
+void OpenCLState::EnableSupportForDouble() {
+  impl_->fp64_support_.push_back(true);
+}
+
 const char* OpenCLState::GetErrorString(int error) {
   switch (error) {
     // run-time and JIT compiler errors

--- a/src/core/gpu/opencl_state.h
+++ b/src/core/gpu/opencl_state.h
@@ -57,7 +57,7 @@ class OpenCLState {
   /// Disable support for double-precision floating point operations
   void DisableSupportForDouble();
 
-/// Enable support for double-precision floating point operations
+  /// Enable support for double-precision floating point operations
   void EnableSupportForDouble();
 
   const char* GetErrorString(int error);

--- a/src/core/gpu/opencl_state.h
+++ b/src/core/gpu/opencl_state.h
@@ -46,6 +46,10 @@ class OpenCLState {
   /// Returns the OpenCL program (kernel) list
   std::vector<cl::Program>* GetOpenCLProgramList();
 
+  std::vector<bool>* GetFp64Support();
+
+  void SelectGpu(int gpu);
+
   /// Returns whether or not a GPU without support for double-precision was
   /// found
   bool HasSupportForDouble();

--- a/src/core/gpu/opencl_state.h
+++ b/src/core/gpu/opencl_state.h
@@ -57,6 +57,9 @@ class OpenCLState {
   /// Disable support for double-precision floating point operations
   void DisableSupportForDouble();
 
+/// Enable support for double-precision floating point operations
+  void EnableSupportForDouble();
+
   const char* GetErrorString(int error);
 
   int ClAssert(int const code, char const* const file, int const line,

--- a/src/core/param/param.h
+++ b/src/core/param/param.h
@@ -623,12 +623,13 @@ struct Param {
   ///     opencl_debug = false
   bool opencl_debug = false;
 
-  /// Set the index of the preferred GPU you wish to use.
+  /// Set the index of the preferred GPU you wish to use. In GpuHelper we
+  /// set the default to whichever GPU supports double precision
   /// Default value: `0`\n
   /// TOML config file:
   ///     [experimental]
-  ///     preferred_gpu = 0
-  int preferred_gpu = 0;
+  ///     preferred_gpu = <GPU with double precision support>
+  int preferred_gpu = -1;
 
   /// Determines if agents' memory layout plots should be generated
   /// during load balancing.


### PR DESCRIPTION
If a device has multiple GPUs with different floating precision capabilities, only the first GPU's capability is considered. This could lead to double-precision-enabled GPUs being ignored and thus resulting in BioDynaMo not using that GPU.

With this PR we check each GPU for it's FP-precision capability and choose the one that is requested for. If no compatible GPU is found, we throw a Fatal to inform the user that BioDynaMo should be compiled for lower precision.