### PR TITLE
Fix discretization offsets in DG

### DIFF
--- a/src/core/diffusion/diffusion_grid.cc
+++ b/src/core/diffusion/diffusion_grid.cc
@@ -256,16 +256,15 @@ void DiffusionGrid::RunInitializers() {
   for (size_t f = 0; f < initializers_.size(); f++) {
     for (uint32_t x = 0; x < nx; x++) {
       real_t real_x = grid_dimensions_[0] +
-                      static_cast<real_t>(x) * box_length_ +
-                      static_cast<real_t>(box_length_) / 2.0;
+                      static_cast<real_t>(x) * box_length_ + box_length_ / 2.0;
       for (uint32_t y = 0; y < ny; y++) {
         real_t real_y = grid_dimensions_[0] +
                         static_cast<real_t>(y) * box_length_ +
-                        static_cast<real_t>(box_length_) / 2.0;
+                        box_length_ / 2.0;
         for (uint32_t z = 0; z < nz; z++) {
           real_t real_z = grid_dimensions_[0] +
                           static_cast<real_t>(z) * box_length_ +
-                          static_cast<real_t>(box_length_) / 2.0;
+                          box_length_ / 2.0;
           std::array<uint32_t, 3> box_coord = {x, y, z};
           size_t idx = GetBoxIndex(box_coord);
           real_t value{0};

--- a/src/core/diffusion/diffusion_grid.cc
+++ b/src/core/diffusion/diffusion_grid.cc
@@ -255,11 +255,17 @@ void DiffusionGrid::RunInitializers() {
   // Apply all functions that initialize this diffusion grid
   for (size_t f = 0; f < initializers_.size(); f++) {
     for (uint32_t x = 0; x < nx; x++) {
-      real_t real_x = grid_dimensions_[0] + x * box_length_;
+      real_t real_x = grid_dimensions_[0] +
+                      static_cast<real_t>(x) * box_length_ +
+                      static_cast<real_t>(box_length_) / 2.0;
       for (uint32_t y = 0; y < ny; y++) {
-        real_t real_y = grid_dimensions_[0] + y * box_length_;
+        real_t real_y = grid_dimensions_[0] +
+                        static_cast<real_t>(y) * box_length_ +
+                        static_cast<real_t>(box_length_) / 2.0;
         for (uint32_t z = 0; z < nz; z++) {
-          real_t real_z = grid_dimensions_[0] + z * box_length_;
+          real_t real_z = grid_dimensions_[0] +
+                          static_cast<real_t>(z) * box_length_ +
+                          static_cast<real_t>(box_length_) / 2.0;
           std::array<uint32_t, 3> box_coord = {x, y, z};
           size_t idx = GetBoxIndex(box_coord);
           real_t value{0};

--- a/src/core/visualization/paraview/vtk_diffusion_grid.cc
+++ b/src/core/visualization/paraview/vtk_diffusion_grid.cc
@@ -119,9 +119,9 @@ void VtkDiffusionGrid::Update(const DiffusionGrid* grid) {
   Dissect(num_boxes[2], tinfo->GetMaxThreads());
   CalcPieceExtents(num_boxes);
   uint64_t xy_num_boxes = num_boxes[0] * num_boxes[1];
-  real_t origin_x = grid_dimensions[0];
-  real_t origin_y = grid_dimensions[2];
-  real_t origin_z = grid_dimensions[4];
+  real_t origin_x = grid_dimensions[0] + box_length / 2.;
+  real_t origin_y = grid_dimensions[2] + box_length / 2.;
+  real_t origin_z = grid_dimensions[4] + box_length / 2.;
 
   // do not partition data for insitu visualization
   if (data_.size() == 1) {

--- a/test/unit/core/diffusion_init_test.cc
+++ b/test/unit/core/diffusion_init_test.cc
@@ -64,29 +64,24 @@ TEST(DiffusionInitTest, GaussianBand) {
   // Initialize data structures with user-defined values
   dgrid->RunInitializers();
 
-  std::array<uint32_t, 3> a = {0, 0, 0};
-  std::array<uint32_t, 3> b = {25, 0, 0};
-  std::array<uint32_t, 3> c = {13, 0, 0};
-  std::array<uint32_t, 3> d = {0, 13, 0};
-  std::array<uint32_t, 3> e = {25, 0, 13};
-  std::array<uint32_t, 3> f = {13, 13, 13};
+  // Define points to evaluate the substance (coincides with the grid points)
+  Double3 a = {5, 0, 0};
+  Double3 b = {245, 0, 0};
+  Double3 c = {135, 0, 0};
+  Double3 d = {5, 135, 0};
+  Double3 e = {245, 0, 135};
+  Double3 f = {135, 135, 135};
 
   auto eps = abs_error<real_t>::value;
   auto conc = dgrid->GetAllConcentrations();
 
-  EXPECT_NEAR(ROOT::Math::normal_pdf(0, 50, 125), conc[dgrid->GetBoxIndex(a)],
-              eps);
-  EXPECT_NEAR(ROOT::Math::normal_pdf(250, 50, 125), conc[dgrid->GetBoxIndex(b)],
-              eps);
-  EXPECT_NEAR(ROOT::Math::normal_pdf(130, 50, 125), conc[dgrid->GetBoxIndex(c)],
-              eps);
-  EXPECT_NEAR(ROOT::Math::normal_pdf(0, 50, 125), conc[dgrid->GetBoxIndex(d)],
-              eps);
+  EXPECT_NEAR(ROOT::Math::normal_pdf(a[0], 50, 125), dgrid->GetValue(a), eps);
+  EXPECT_NEAR(ROOT::Math::normal_pdf(b[0], 50, 125), dgrid->GetValue(b), eps);
+  EXPECT_NEAR(ROOT::Math::normal_pdf(c[0], 50, 125), dgrid->GetValue(c), eps);
+  EXPECT_NEAR(ROOT::Math::normal_pdf(d[0], 50, 125), dgrid->GetValue(d), eps);
   // Should be symmetric, so the two ends should have the same value
-  EXPECT_NEAR(ROOT::Math::normal_pdf(0, 50, 125), conc[dgrid->GetBoxIndex(e)],
-              eps);
-  EXPECT_NEAR(ROOT::Math::normal_pdf(130, 50, 125), conc[dgrid->GetBoxIndex(f)],
-              eps);
+  EXPECT_NEAR(ROOT::Math::normal_pdf(e[0], 50, 125), dgrid->GetValue(e), eps);
+  EXPECT_NEAR(ROOT::Math::normal_pdf(f[0], 50, 125), dgrid->GetValue(f), eps);
 }
 
 // Both internal arrays (c1_ and c2_) need to be initialized to avoid unphysical

--- a/test/unit/core/diffusion_init_test.cc
+++ b/test/unit/core/diffusion_init_test.cc
@@ -65,15 +65,14 @@ TEST(DiffusionInitTest, GaussianBand) {
   dgrid->RunInitializers();
 
   // Define points to evaluate the substance (coincides with the grid points)
-  Double3 a = {5, 0, 0};
-  Double3 b = {245, 0, 0};
-  Double3 c = {135, 0, 0};
-  Double3 d = {5, 135, 0};
-  Double3 e = {245, 0, 135};
-  Double3 f = {135, 135, 135};
+  Real3 a = {5, 0, 0};
+  Real3 b = {245, 0, 0};
+  Real3 c = {135, 0, 0};
+  Real3 d = {5, 135, 0};
+  Real3 e = {245, 0, 135};
+  Real3 f = {135, 135, 135};
 
   auto eps = abs_error<real_t>::value;
-  auto conc = dgrid->GetAllConcentrations();
 
   EXPECT_NEAR(ROOT::Math::normal_pdf(a[0], 50, 125), dgrid->GetValue(a), eps);
   EXPECT_NEAR(ROOT::Math::normal_pdf(b[0], 50, 125), dgrid->GetValue(b), eps);

--- a/test/unit/core/visualization/paraview/integration_test.cc
+++ b/test/unit/core/visualization/paraview/integration_test.cc
@@ -86,13 +86,8 @@ void RunDiffusionGridTest(uint64_t max_bound, uint64_t resolution,
   ModelInitializer::InitializeSubstance(0, [&](real_t x, real_t y, real_t z) {
     auto* dgrid =
         Simulation::GetActive()->GetResourceManager()->GetDiffusionGrid(0);
-    auto grid_dimensions = dgrid->GetDimensions();
-    auto box_length = dgrid->GetBoxLength();
 
-    std::array<uint32_t, 3> box_coord;
-    box_coord[0] = round((x - grid_dimensions[0]) / box_length);
-    box_coord[1] = round((y - grid_dimensions[2]) / box_length);
-    box_coord[2] = round((z - grid_dimensions[4]) / box_length);
+    std::array<uint32_t, 3> box_coord = dgrid->GetBoxCoordinates({x, y, z});
     const auto& num_boxes = dgrid->GetNumBoxesArray();
     return box_coord[2] * num_boxes[0] * num_boxes[1] +
            box_coord[1] * num_boxes[0] + box_coord[0];


### PR DESCRIPTION
This PR targets issue #311. In this PR, we shift the ParaView export by half a box length. Effectively, this means we change the discretization points from the top left, to the center of the boxes. See below form `x -> o`. We additionally change the initializers for the `DiffusionGrid` because these need to be evaluated at the new discretization points. Two tests needed to be modified in this process as well. 

```
x-----------x-----------x------------
|           |           |           |
|     o     |     o     |     o     |
|           |           |           |
-------------------------------------
x-----------x-----------x------------
|           |           |           |
|     o     |     o     |     o     |
|           |           |           |
-------------------------------------
x-----------x-----------x------------
|           |           |           |
|     o     |     o     |     o     |
|           |           |           |
-------------------------------------
``` 