### PR TITLE
Add on-the-fly gradient computation

### DIFF
--- a/src/core/diffusion/diffusion_grid.cc
+++ b/src/core/diffusion/diffusion_grid.cc
@@ -495,7 +495,6 @@ size_t DiffusionGrid::GetBoxIndex(const Real3& position) const {
 }
 
 std::array<size_t, 6> DiffusionGrid::GetNeighboringBoxes(size_t index) const {
-  std::array<size_t, 6> neighbors;
   const auto box_coord = GetBoxCoordinates(index);
   return GetNeighboringBoxes(index, box_coord);
 };


### PR DESCRIPTION
Computing all gradients in the diffusion grid can be 3x more costly than computing the diffusion itself. There are many use cases that only require the gradient at a hand full of positions. The diffusion computation cannot be avoided but we can avoid computing all gradients and just compute it at the relevant positions. 

This PR:

- Adds on-the-fly gradient evaluation, e.g. without pre-computing
- Contains a hot fix for faulty `DiffusionGrid::GetBoxCoordinates(const Real3& position)`
- Fixes the old gradient computation at the boundary
- Introduces thorough tests for the gradient computation (e.g. test gradient at all discretization points, not just some randomly selected)
- Adds a few helper functions for converting indices plus accompanying unit tests