### PR TITLE
Remove name attribute from Chemotaxis and Secretion classes

### DIFF
--- a/src/core/behavior/chemotaxis.h
+++ b/src/core/behavior/chemotaxis.h
@@ -28,23 +28,19 @@ class Chemotaxis : public Behavior {
 
  public:
   Chemotaxis() = default;
-  Chemotaxis(const std::string& substance, real_t speed)
-      : substance_(substance), speed_(speed) {
+  Chemotaxis(const std::string& substance, real_t speed) : speed_(speed) {
     dgrid_ = Simulation::GetActive()->GetResourceManager()->GetDiffusionGrid(
         substance);
   }
 
   explicit Chemotaxis(DiffusionGrid* dgrid, real_t speed)
-      : dgrid_(dgrid), speed_(speed) {
-    substance_ = dgrid->GetContinuumName();
-  }
+      : dgrid_(dgrid), speed_(speed) {}
 
   virtual ~Chemotaxis() = default;
 
   void Initialize(const NewAgentEvent& event) override {
     Base::Initialize(event);
     auto* other = bdm_static_cast<Chemotaxis*>(event.existing_behavior);
-    substance_ = other->substance_;
     dgrid_ = other->dgrid_;
     speed_ = other->speed_;
   }
@@ -58,7 +54,6 @@ class Chemotaxis : public Behavior {
   }
 
  private:
-  std::string substance_;
   DiffusionGrid* dgrid_ = nullptr;
   real_t speed_;
 };

--- a/src/core/behavior/secretion.h
+++ b/src/core/behavior/secretion.h
@@ -32,23 +32,20 @@ class Secretion : public Behavior {
   Secretion() = default;
   explicit Secretion(const std::string& substance, real_t quantity = 1,
                      InteractionMode mode = InteractionMode::kAdditive)
-      : substance_(substance), quantity_(quantity), mode_(mode) {
+      : quantity_(quantity), mode_(mode) {
     dgrid_ = Simulation::GetActive()->GetResourceManager()->GetDiffusionGrid(
         substance);
   }
 
   explicit Secretion(DiffusionGrid* dgrid, real_t quantity = 1,
                      InteractionMode mode = InteractionMode::kAdditive)
-      : dgrid_(dgrid), quantity_(quantity), mode_(mode) {
-    substance_ = dgrid->GetContinuumName();
-  }
+      : dgrid_(dgrid), quantity_(quantity), mode_(mode) {}
 
   virtual ~Secretion() = default;
 
   void Initialize(const NewAgentEvent& event) override {
     Base::Initialize(event);
     auto* other = bdm_static_cast<Secretion*>(event.existing_behavior);
-    substance_ = other->substance_;
     dgrid_ = other->dgrid_;
     quantity_ = other->quantity_;
   }
@@ -59,7 +56,6 @@ class Secretion : public Behavior {
   }
 
  private:
-  std::string substance_;
   DiffusionGrid* dgrid_ = nullptr;
   real_t quantity_ = 1;
   InteractionMode mode_ = InteractionMode::kAdditive;


### PR DESCRIPTION
Reduce memory footprint, by removing these unused attributes.
The name can be obtained from the diffusion grid.