### PR TITLE
Add flag to turn off gradient computation for DG

### DIFF
--- a/src/core/diffusion/diffusion_grid.cc
+++ b/src/core/diffusion/diffusion_grid.cc
@@ -305,6 +305,9 @@ void DiffusionGrid::CalculateGradient() {
   if (init_gradient_ && IsFixedSubstance()) {
     return;
   }
+  if (!precompute_gradients_) {
+    return;
+  }
 
 #pragma omp parallel for collapse(2)
   for (uint32_t z = 0; z < resolution_; z++) {

--- a/src/core/diffusion/diffusion_grid.h
+++ b/src/core/diffusion/diffusion_grid.h
@@ -340,6 +340,10 @@ class DiffusionGrid : public ScalarField {
   /// Returns if the grid has been initialized
   bool IsInitialized() const { return initialized_; }
 
+  /// Turn off the gradient calculation. Gradients are not precomputed but
+  /// can be calculated on the fly.
+  void TurnOffGradientCalculation() { precompute_gradients_ = false; }
+
  private:
   friend class RungeKuttaGrid;
   friend class EulerGrid;
@@ -413,6 +417,9 @@ class DiffusionGrid : public ScalarField {
   /// Flag to indicate if we want to print information about the grid after
   /// initialization
   bool print_info_with_initialization_ = false;
+  /// Flag to avoid gradient computation if not needed. (E.g. if multiple DGs
+  /// are used but the gradient is only needed for one of them.)
+  bool precompute_gradients_ = true;
 
   BDM_CLASS_DEF_OVERRIDE(DiffusionGrid, 1);
 };


### PR DESCRIPTION
If we have multiple DG but only need the gradient information for one of them, we're doing a lot of unnecessary computation. This PR adds a flag to turn off the gradient computation such that this can be avoided.