### PR TITLE
Avoid implicit conversion

### DIFF
--- a/src/core/agent/agent_pointer.h
+++ b/src/core/agent/agent_pointer.h
@@ -90,12 +90,12 @@ class AgentPointer {
 
   uint64_t GetUidAsUint64() const {
     if (*this == nullptr) {
-      return AgentUid();
+      return static_cast<uint64_t>(AgentUid());
     }
     if (gAgentPointerMode == AgentPointerMode::kIndirect) {
-      return d_.uid;
+      return static_cast<uint64_t>(d_.uid);
     } else {
-      return d_.agent->GetUid();
+      return static_cast<uint64_t>(d_.agent->GetUid());
     }
   }
 

--- a/src/core/agent/agent_pointer.h
+++ b/src/core/agent/agent_pointer.h
@@ -211,6 +211,9 @@ class AgentPointer {
 
   const TAgent& operator*() const { return *(this->operator->()); }
 
+  // Note: allow for implicit conversion to bool
+  /// Allows to use `if (agent_ptr) { ... }`. Returns true if the pointer is not
+  /// nullptr.
   operator bool() const { return *this != nullptr; }  // NOLINT
 
   operator AgentPointer<Agent>() const {

--- a/src/core/agent/agent_uid.h
+++ b/src/core/agent/agent_uid.h
@@ -90,7 +90,7 @@ class AgentUid {
     return *this;
   }
 
-  operator uint64_t() const {
+  explicit operator uint64_t() const {
     return (static_cast<uint64_t>(reused_) << 32) |
            static_cast<uint64_t>(index_);
   }

--- a/src/core/analysis/style.h
+++ b/src/core/analysis/style.h
@@ -31,7 +31,7 @@ class Style : public TNamed,
  public:
   Style();
   ~Style();
-  operator TStyle*() const;
+  explicit operator TStyle*() const;
   TStyle* GetTStyle() const;
 
  private:
@@ -39,24 +39,24 @@ class Style : public TNamed,
 
   // The following attributes were copied from TStyle
 
-  TAttAxis fXaxis;         ///< X axis attributes
-  TAttAxis fYaxis;         ///< Y axis attributes
-  TAttAxis fZaxis;         ///< Z axis attributes
-  Float_t fBarWidth;       ///< Width of bar for graphs
-  Float_t fBarOffset;      ///< Offset of bar for graphs
-  Int_t fColorModelPS;     ///< PostScript color model: 0 = RGB, 1 = CMYK
-  Int_t fDrawBorder;       ///< Flag to draw border(=1) or not (0)
-  Int_t fOptLogx;          ///< True if log scale in X
-  Int_t fOptLogy;          ///< True if log scale in y
-  Int_t fOptLogz;          ///< True if log scale in z
-  Int_t fOptDate;          ///< True if date option is selected
-  Int_t fOptStat;          ///< True if option Stat is selected
-  Int_t fOptTitle;         ///< True if option Title is selected
-  Int_t fOptFile;          ///< True if option File is selected
-  Int_t fOptFit;           ///< True if option Fit is selected
-  Int_t fShowEventStatus;  ///< Show event status panel
-  Int_t fShowEditor;       ///< Show pad editor
-  Int_t fShowToolBar;      ///< Show toolbar
+  TAttAxis fXaxis;            ///< X axis attributes
+  TAttAxis fYaxis;            ///< Y axis attributes
+  TAttAxis fZaxis;            ///< Z axis attributes
+  Float_t fBarWidth;          ///< Width of bar for graphs
+  Float_t fBarOffset;         ///< Offset of bar for graphs
+  Int_t fColorModelPS;        ///< PostScript color model: 0 = RGB, 1 = CMYK
+  Int_t fDrawBorder;          ///< Flag to draw border(=1) or not (0)
+  Int_t fOptLogx;             ///< True if log scale in X
+  Int_t fOptLogy;             ///< True if log scale in y
+  Int_t fOptLogz;             ///< True if log scale in z
+  Int_t fOptDate;             ///< True if date option is selected
+  Int_t fOptStat;             ///< True if option Stat is selected
+  Int_t fOptTitle;            ///< True if option Title is selected
+  Int_t fOptFile;             ///< True if option File is selected
+  Int_t fOptFit;              ///< True if option Fit is selected
+  Int_t fShowEventStatus;     ///< Show event status panel
+  Int_t fShowEditor;          ///< Show pad editor
+  Int_t fShowToolBar;         ///< Show toolbar
 
   Int_t fNumberContours;      ///< Default number of contours for 2-d plots
   TAttText fAttDate;          ///< Canvas date attribute

--- a/src/core/environment/morton_order.cc
+++ b/src/core/environment/morton_order.cc
@@ -22,7 +22,7 @@ namespace bdm {
 template <typename T>
 class Stack {
  public:
-  Stack(uint64_t max_elements) { data_.resize(max_elements); }
+  explicit Stack(uint64_t max_elements) { data_.resize(max_elements); }
 
   void Push(const T& el) {
     data_[++top_] = el;

--- a/src/core/environment/uniform_grid_environment.h
+++ b/src/core/environment/uniform_grid_environment.h
@@ -614,7 +614,7 @@ class UniformGridEnvironment : public Environment {
  private:
   class LoadBalanceInfoUG : public LoadBalanceInfo {
    public:
-    LoadBalanceInfoUG(UniformGridEnvironment* grid);
+    explicit LoadBalanceInfoUG(UniformGridEnvironment* grid);
     virtual ~LoadBalanceInfoUG();
     void Update();
     void CallHandleIteratorConsumer(

--- a/src/core/functor.h
+++ b/src/core/functor.h
@@ -42,7 +42,7 @@ struct LambdaFunctor<TReturn (TLambda::*)(TArgs...) const> final
     : public Functor<TReturn, TArgs...> {
   TLambda lambda;
 
-  LambdaFunctor(const TLambda& lambda) : lambda(lambda) {}
+  explicit LambdaFunctor(const TLambda& lambda) : lambda(lambda) {}
   LambdaFunctor(const LambdaFunctor& other) : lambda(other.lambda) {}
   virtual ~LambdaFunctor() = default;
 
@@ -57,7 +57,7 @@ struct LambdaFunctor<TReturn (TLambda::*)(TArgs...)> final
     : public Functor<TReturn, TArgs...> {
   TLambda lambda;
 
-  LambdaFunctor(const TLambda& lambda) : lambda(lambda) {}
+  explicit LambdaFunctor(const TLambda& lambda) : lambda(lambda) {}
   LambdaFunctor(const LambdaFunctor& other) : lambda(other.lambda) {}
   virtual ~LambdaFunctor() = default;
 

--- a/src/core/util/random.h
+++ b/src/core/util/random.h
@@ -33,7 +33,7 @@ template <typename TSample>
 class DistributionRng {
  public:
   DistributionRng() = default;
-  DistributionRng(TRootIOCtor*) {}
+  explicit DistributionRng(TRootIOCtor*) {}
   virtual ~DistributionRng() = default;
   /// Draws a sample from the distribution
   TSample Sample();
@@ -89,7 +89,7 @@ class GausRng : public DistributionRng<real_t> {
 // -----------------------------------------------------------------------------
 class ExpRng : public DistributionRng<real_t> {
  public:
-  ExpRng(real_t tau);
+  explicit ExpRng(real_t tau);
   virtual ~ExpRng();
 
  private:
@@ -113,7 +113,7 @@ class LandauRng : public DistributionRng<real_t> {
 // -----------------------------------------------------------------------------
 class PoissonDRng : public DistributionRng<real_t> {
  public:
-  PoissonDRng(real_t mean);
+  explicit PoissonDRng(real_t mean);
   virtual ~PoissonDRng();
 
  private:
@@ -137,7 +137,8 @@ class BreitWignerRng : public DistributionRng<real_t> {
 // -----------------------------------------------------------------------------
 class UserDefinedDistRng1D : public DistributionRng<real_t> {
  public:
-  UserDefinedDistRng1D(TRootIOCtor* ioctor) : DistributionRng<real_t>(ioctor) {}
+  explicit UserDefinedDistRng1D(TRootIOCtor* ioctor)
+      : DistributionRng<real_t>(ioctor) {}
   UserDefinedDistRng1D(TF1* function, const char* option);
   virtual ~UserDefinedDistRng1D();
   void Draw(const char* option = "");
@@ -154,7 +155,8 @@ class UserDefinedDistRng1D : public DistributionRng<real_t> {
 // -----------------------------------------------------------------------------
 class UserDefinedDistRng2D : public DistributionRng<real_t> {
  public:
-  UserDefinedDistRng2D(TRootIOCtor* ioctor) : DistributionRng<real_t>(ioctor) {}
+  explicit UserDefinedDistRng2D(TRootIOCtor* ioctor)
+      : DistributionRng<real_t>(ioctor) {}
   UserDefinedDistRng2D(TF2* function, const char* option);
   virtual ~UserDefinedDistRng2D();
   void Draw(const char* option = "");
@@ -172,7 +174,8 @@ class UserDefinedDistRng2D : public DistributionRng<real_t> {
 // -----------------------------------------------------------------------------
 class UserDefinedDistRng3D : public DistributionRng<real_t> {
  public:
-  UserDefinedDistRng3D(TRootIOCtor* ioctor) : DistributionRng<real_t>(ioctor) {}
+  explicit UserDefinedDistRng3D(TRootIOCtor* ioctor)
+      : DistributionRng<real_t>(ioctor) {}
   UserDefinedDistRng3D(TF3* function, const char* option);
   virtual ~UserDefinedDistRng3D();
   void Draw(const char* option = "");
@@ -246,7 +249,7 @@ class BinomialRng : public DistributionRng<int> {
 // -----------------------------------------------------------------------------
 class PoissonRng : public DistributionRng<int> {
  public:
-  PoissonRng(real_t mean);
+  explicit PoissonRng(real_t mean);
   virtual ~PoissonRng();
 
  private:

--- a/src/core/visualization/paraview/mapped_data_array.h
+++ b/src/core/visualization/paraview/mapped_data_array.h
@@ -93,7 +93,7 @@ struct GetDataMemberForVis {
     auto* casted_agent = static_cast<TClass*>(agent);
     auto* data = reinterpret_cast<TDataMember*>(
         reinterpret_cast<char*>(casted_agent) + dm_offset_);
-    uint64_t uid = *data;
+    uint64_t uid = static_cast<uint64_t>(*data);
     auto tid = ThreadInfo::GetInstance()->GetUniversalThreadId();
     assert(temp_values_.size() > tid);
     temp_values_[tid][0] = uid;

--- a/src/core/visualization/root/adaptor.h
+++ b/src/core/visualization/root/adaptor.h
@@ -139,7 +139,8 @@ class RootAdaptor {
 
   /// Adds a sphere object to the volume
   void AddSphere(const Agent *agent, TGeoVolume *container) {
-    std::string name = agent->GetTypeName() + std::to_string(agent->GetUid());
+    std::string name = agent->GetTypeName() +
+                       std::to_string(static_cast<uint64_t>(agent->GetUid()));
     auto radius = agent->GetDiameter() / 2;
     auto massLocation = agent->GetPosition();
     auto x = massLocation[0];
@@ -154,7 +155,8 @@ class RootAdaptor {
   /// Adds a cylinder object to the volume
   void AddCylinder(const Agent *agent, TGeoVolume *container) {
     if (auto neurite = dynamic_cast<const NeuriteElement *>(agent)) {
-      std::string name = agent->GetTypeName() + std::to_string(agent->GetUid());
+      std::string name = agent->GetTypeName() +
+                         std::to_string(static_cast<uint64_t>(agent->GetUid()));
       auto radius = neurite->GetDiameter() / 2;
       auto half_length = neurite->GetLength() / 2;
       auto massLocation = neurite->GetPosition();

--- a/test/unit/core/agent/agent_uid_test.cc
+++ b/test/unit/core/agent/agent_uid_test.cc
@@ -91,13 +91,13 @@ TEST(AgentUidTest, MinusOperator) {
 
 TEST(AgentUidTest, uint64_tOperator) {
   AgentUid uid(123, 0);
-  uint64_t idx = uid;
+  uint64_t idx = static_cast<uint64_t>(uid);
   EXPECT_EQ(idx, 123u);
 }
 
 TEST(AgentUidTest, uint64_tOperator2) {
   AgentUid uid(123, 2);
-  uint64_t idx = uid;
+  uint64_t idx = static_cast<uint64_t>(uid);
   EXPECT_EQ(idx, 8589934715u);  // (2 << 32) | 123u);
 }
 

--- a/test/unit/core/environment/uniform_grid_environment_test.cc
+++ b/test/unit/core/environment/uniform_grid_environment_test.cc
@@ -407,7 +407,7 @@ struct ZOrderCallback : Functor<void, const AgentHandle&> {
       box_cnt++;
     }
     auto* agent = rm->GetAgent(ah);
-    zorder[box_cnt].insert(agent->GetUid() - ref_uid);
+    zorder[box_cnt].insert(agent->GetUid() - static_cast<uint64_t>(ref_uid));
     cnt++;
   }
 };

--- a/test/unit/core/resource_manager_test.cc
+++ b/test/unit/core/resource_manager_test.cc
@@ -41,7 +41,8 @@ TEST(ResourceManagerTest, ForEachAgentFilter) {
   rm->ForEachAgent(
       [&](Agent* a) {  // NOLINT
         counter++;
-        switch (a->GetUid() - ref_uid) {
+        switch (static_cast<uint64_t>(a->GetUid()) -
+                static_cast<uint64_t>(ref_uid)) {
           case 0:
             EXPECT_EQ(0, dynamic_cast<TestAgent*>(a)->GetData());
             break;
@@ -63,7 +64,8 @@ TEST(ResourceManagerTest, ForEachAgentFilter) {
   rm->ForEachAgent(
       [&](Agent* a) {  // NOLINT
         counter++;
-        switch (a->GetUid() - ref_uid) {
+        switch (static_cast<uint64_t>(a->GetUid()) -
+                static_cast<uint64_t>(ref_uid)) {
           case 1:
             EXPECT_EQ(1, dynamic_cast<TestAgent*>(a)->GetData());
             break;

--- a/test/unit/core/resource_manager_test.h
+++ b/test/unit/core/resource_manager_test.h
@@ -72,7 +72,8 @@ inline void RunForEachAgentTest() {
   uint64_t counter = 0;
   rm->ForEachAgent([&](Agent* element) {  // NOLINT
     counter++;
-    switch (element->GetUid() - ref_uid) {
+    switch (static_cast<uint64_t>(element->GetUid()) -
+            static_cast<uint64_t>(ref_uid)) {
       case 0:
         EXPECT_EQ(12, dynamic_cast<A*>(element)->GetData());
         break;


### PR DESCRIPTION
* MISRA C++:2008, 12-1-3 - All constructors that are callable with a single argument of fundamental type shall be declared explicit.
* C++ Core Guidelines C.46 - By default, declare single-argument constructors explicit
* C++ Core Guidelines C.164 - Avoid implicit conversion operators