### PR TITLE
Fix function specifiers (virtual, override, final)

### DIFF
--- a/src/core/agent/cell.h
+++ b/src/core/agent/cell.h
@@ -59,7 +59,7 @@ class Cell : public Agent {
     UpdateVolume();
   }
 
-  virtual ~Cell() = default;
+  ~Cell() override = default;
 
   /// \brief This method is used to initialise the values of daughter
   /// 2 for a cell division event.

--- a/src/core/agent/cell_division_event.h
+++ b/src/core/agent/cell_division_event.h
@@ -34,7 +34,7 @@ struct CellDivisionEvent : public NewAgentEvent {
   CellDivisionEvent(real_t volume_ratio, real_t phi, real_t theta)
       : volume_ratio(volume_ratio), phi(phi), theta(theta) {}
 
-  virtual ~CellDivisionEvent() = default;
+  ~CellDivisionEvent() override = default;
 
   NewAgentEventUid GetUid() const override { return kUid; }
 

--- a/src/core/analysis/reduce.h
+++ b/src/core/analysis/reduce.h
@@ -36,7 +36,7 @@ namespace experimental {
 /// can be combined to avoid iterating over all agents multiple times.\n
 template <typename TResult>
 struct Reducer : public Functor<void, Agent*> {
-  virtual ~Reducer() = default;
+  ~Reducer() override = default;
   virtual TResult GetResult() = 0;
   /// Resets the internal state between calculations.
   virtual void Reset() = 0;

--- a/src/core/environment/kd_tree_environment.h
+++ b/src/core/environment/kd_tree_environment.h
@@ -73,7 +73,7 @@ class KDTreeEnvironment : public Environment {
 
   KDTreeEnvironment();
 
-  ~KDTreeEnvironment();
+  ~KDTreeEnvironment() override;
 
   std::array<int32_t, 6> GetDimensions() const override;
 

--- a/src/core/environment/morton_order.cc
+++ b/src/core/environment/morton_order.cc
@@ -168,7 +168,7 @@ class MortonIterator : public Iterator<uint64_t> {
         next_morton_code_(start_morton_code),
         offset_pos_(offset_pos),
         offset_index_(offset_index) {}
-  virtual ~MortonIterator() = default;
+  ~MortonIterator() override = default;
 
   bool HasNext() const override { return next_index_ <= last_index_; }
 

--- a/src/core/environment/octree_environment.h
+++ b/src/core/environment/octree_environment.h
@@ -46,7 +46,7 @@ class OctreeEnvironment : public Environment {
 
   OctreeEnvironment();
 
-  ~OctreeEnvironment();
+  ~OctreeEnvironment() override;
 
   std::array<int32_t, 6> GetDimensions() const override;
 

--- a/src/core/environment/uniform_grid_environment.h
+++ b/src/core/environment/uniform_grid_environment.h
@@ -233,7 +233,7 @@ class UniformGridEnvironment : public Environment {
   UniformGridEnvironment(UniformGridEnvironment const&) = delete;
   void operator=(UniformGridEnvironment const&) = delete;
 
-  virtual ~UniformGridEnvironment() = default;
+  ~UniformGridEnvironment() override = default;
 
   /// Clears the grid
   void Clear() override {
@@ -615,7 +615,7 @@ class UniformGridEnvironment : public Environment {
   class LoadBalanceInfoUG : public LoadBalanceInfo {
    public:
     LoadBalanceInfoUG(UniformGridEnvironment* grid);
-    virtual ~LoadBalanceInfoUG();
+    ~LoadBalanceInfoUG() override;
     void Update();
     void CallHandleIteratorConsumer(
         uint64_t start, uint64_t end,
@@ -636,7 +636,7 @@ class UniformGridEnvironment : public Environment {
       InitializeVectorFunctor(UniformGridEnvironment* grid, uint64_t start,
                               decltype(sorted_boxes) sorted_boxes,
                               decltype(cummulated_agents) cummulated_agents);
-      virtual ~InitializeVectorFunctor();
+      ~InitializeVectorFunctor() override;
 
       void operator()(Iterator<uint64_t>* it) override;
     };

--- a/src/core/execution_context/copy_execution_context.h
+++ b/src/core/execution_context/copy_execution_context.h
@@ -43,7 +43,7 @@ class CopyExecutionContext : public InPlaceExecutionContext {
       const std::shared_ptr<ThreadSafeAgentUidMap>& map,
       std::shared_ptr<std::vector<std::vector<Agent*>>> agents);
 
-  virtual ~CopyExecutionContext();
+  ~CopyExecutionContext() override;
 
   void SetupIterationAll(
       const std::vector<ExecutionContext*>& all_exec_ctxts) override;

--- a/src/core/execution_context/in_place_exec_ctxt.h
+++ b/src/core/execution_context/in_place_exec_ctxt.h
@@ -75,7 +75,7 @@ class InPlaceExecutionContext : public ExecutionContext {
   explicit InPlaceExecutionContext(
       const std::shared_ptr<ThreadSafeAgentUidMap>& map);
 
-  virtual ~InPlaceExecutionContext();
+  ~InPlaceExecutionContext() override;
 
   /// This function is called at the beginning of each iteration to setup all
   /// execution contexts.

--- a/src/core/multi_simulation/mpi_helper.h
+++ b/src/core/multi_simulation/mpi_helper.h
@@ -39,11 +39,11 @@ namespace experimental {
 class MPIObject : public TMessage {
  public:
   MPIObject() = default;
-  ~MPIObject() = default;
+  ~MPIObject() override = default;
   MPIObject(void* buf, Int_t len) : TMessage(buf, len) {}
 
  private:
-  BDM_CLASS_DEF(MPIObject, 1);
+  BDM_CLASS_DEF_OVERRIDE(MPIObject, 1);
 };
 
 // Hide MPI functions from Cling

--- a/src/core/operation/mechanical_forces_op.h
+++ b/src/core/operation/mechanical_forces_op.h
@@ -57,7 +57,7 @@ class MechanicalForcesOp : public AgentOperationImpl {
     }
   }
 
-  virtual ~MechanicalForcesOp() {
+  ~MechanicalForcesOp() override {
     if (force_) {
       delete force_;
     }

--- a/src/core/operation/mechanical_forces_op_cuda.cc
+++ b/src/core/operation/mechanical_forces_op_cuda.cc
@@ -68,7 +68,7 @@ struct InitializeGPUData : public Functor<void, Agent*, AgentHandle> {
 
   InitializeGPUData();
 
-  virtual ~InitializeGPUData();
+  ~InitializeGPUData() override;
 
   void Initialize(uint64_t num_agents, uint64_t num_boxes,
                   const std::vector<AgentHandle::ElementIdx_t>& offs,
@@ -202,7 +202,7 @@ struct UpdateCPUResults : public Functor<void, Agent*, AgentHandle> {
 
   UpdateCPUResults(real_t* cm,
                    const std::vector<AgentHandle::ElementIdx_t>& offs);
-  virtual ~UpdateCPUResults();
+  ~UpdateCPUResults() override;
 
   void operator()(Agent* agent, AgentHandle ah) override;
 };

--- a/src/core/operation/reduction_op.h
+++ b/src/core/operation/reduction_op.h
@@ -39,7 +39,7 @@ class ReductionOp : public AgentOperationImpl {
     tl_results_.resize(ThreadInfo::GetInstance()->GetMaxThreads());
   }
 
-  ~ReductionOp() {
+  ~ReductionOp() override {
     delete agent_functor_;
     delete reduce_functor_;
   }

--- a/src/core/operation/visualization_op.h
+++ b/src/core/operation/visualization_op.h
@@ -27,7 +27,7 @@ class VisualizationOp : public StandaloneOperationImpl {
   BDM_OP_HEADER(VisualizationOp);
 
  public:
-  virtual ~VisualizationOp() {
+  ~VisualizationOp() override {
     if (visualization_) {
       delete visualization_;
     }

--- a/src/core/resource_manager.cc
+++ b/src/core/resource_manager.cc
@@ -86,7 +86,7 @@ template <typename TFunctor>
 struct ForEachAgentParallelFunctor : public Functor<void, Agent*, AgentHandle> {
   TFunctor& functor_;
   explicit ForEachAgentParallelFunctor(TFunctor& f) : functor_(f) {}
-  void operator()(Agent* agent, AgentHandle) { functor_(agent); }
+  void operator()(Agent* agent, AgentHandle) override { functor_(agent); }
 };
 
 void ResourceManager::ForEachAgentParallel(Functor<void, Agent*>& function,
@@ -218,7 +218,7 @@ struct LoadBalanceFunctor : public Functor<void, Iterator<AgentHandle>*> {
         uid_ah_map(uid_ah_map),
         type_index(type_index) {}
 
-  void operator()(Iterator<AgentHandle>* it) {
+  void operator()(Iterator<AgentHandle>* it) override {
     while (it->HasNext()) {
       auto handle = it->Next();
       auto* agent = agents[handle.GetNumaNode()][handle.GetElementIdx()];

--- a/src/core/util/plot_memory_layout.cc
+++ b/src/core/util/plot_memory_layout.cc
@@ -109,7 +109,7 @@ struct Fen : public Functor<void, Agent*, real_t> {
   Agent* query;
   Fen(std::vector<int64_t>& diffs, Agent* query) : diffs(diffs), query(query) {}
 
-  void operator()(Agent* neighbor, real_t) {
+  void operator()(Agent* neighbor, real_t) override {
     if (neighbor == query) {
       return;
     }
@@ -124,7 +124,7 @@ struct Fea : public Functor<void, Agent*, AgentHandle> {
   std::vector<int64_t>& diffs;
   explicit Fea(std::vector<int64_t>& diffs) : diffs(diffs) {}
 
-  void operator()(Agent* agent, AgentHandle) {
+  void operator()(Agent* agent, AgentHandle) override {
     Fen fen(diffs, agent);
     auto* sim = Simulation::GetActive();
     auto* env = sim->GetEnvironment();

--- a/src/core/util/random.h
+++ b/src/core/util/random.h
@@ -66,7 +66,7 @@ class DistributionRng {
 class UniformRng : public DistributionRng<real_t> {
  public:
   UniformRng(real_t min, real_t max);
-  virtual ~UniformRng();
+  ~UniformRng() override;
 
  private:
   real_t min_, max_;
@@ -78,7 +78,7 @@ class UniformRng : public DistributionRng<real_t> {
 class GausRng : public DistributionRng<real_t> {
  public:
   GausRng(real_t mean, real_t sigma);
-  virtual ~GausRng();
+  virtual ~GausRng() override;
 
  private:
   real_t mean_, sigma_;
@@ -90,7 +90,7 @@ class GausRng : public DistributionRng<real_t> {
 class ExpRng : public DistributionRng<real_t> {
  public:
   ExpRng(real_t tau);
-  virtual ~ExpRng();
+  ~ExpRng() override;
 
  private:
   real_t tau_;
@@ -102,7 +102,7 @@ class ExpRng : public DistributionRng<real_t> {
 class LandauRng : public DistributionRng<real_t> {
  public:
   LandauRng(real_t mean, real_t sigma);
-  virtual ~LandauRng();
+  ~LandauRng() override;
 
  private:
   real_t mean_, sigma_;
@@ -114,7 +114,7 @@ class LandauRng : public DistributionRng<real_t> {
 class PoissonDRng : public DistributionRng<real_t> {
  public:
   PoissonDRng(real_t mean);
-  virtual ~PoissonDRng();
+  ~PoissonDRng() override;
 
  private:
   real_t mean_;
@@ -126,7 +126,7 @@ class PoissonDRng : public DistributionRng<real_t> {
 class BreitWignerRng : public DistributionRng<real_t> {
  public:
   BreitWignerRng(real_t mean, real_t gamma);
-  virtual ~BreitWignerRng();
+  ~BreitWignerRng() override;
 
  private:
   real_t mean_, gamma_;
@@ -139,7 +139,7 @@ class UserDefinedDistRng1D : public DistributionRng<real_t> {
  public:
   UserDefinedDistRng1D(TRootIOCtor* ioctor) : DistributionRng<real_t>(ioctor) {}
   UserDefinedDistRng1D(TF1* function, const char* option);
-  virtual ~UserDefinedDistRng1D();
+  ~UserDefinedDistRng1D() override;
   void Draw(const char* option = "");
   TF1* GetTF1();
 
@@ -156,7 +156,7 @@ class UserDefinedDistRng2D : public DistributionRng<real_t> {
  public:
   UserDefinedDistRng2D(TRootIOCtor* ioctor) : DistributionRng<real_t>(ioctor) {}
   UserDefinedDistRng2D(TF2* function, const char* option);
-  virtual ~UserDefinedDistRng2D();
+  ~UserDefinedDistRng2D() override;
   void Draw(const char* option = "");
   TF2* GetTF2();
 
@@ -174,7 +174,7 @@ class UserDefinedDistRng3D : public DistributionRng<real_t> {
  public:
   UserDefinedDistRng3D(TRootIOCtor* ioctor) : DistributionRng<real_t>(ioctor) {}
   UserDefinedDistRng3D(TF3* function, const char* option);
-  virtual ~UserDefinedDistRng3D();
+  ~UserDefinedDistRng3D() override;
   void Draw(const char* option = "");
   TF3* GetTF3();
 
@@ -234,7 +234,7 @@ namespace bdm {
 class BinomialRng : public DistributionRng<int> {
  public:
   BinomialRng(int ntot, real_t prob);
-  virtual ~BinomialRng();
+  ~BinomialRng() override;
 
  private:
   int ntot_;
@@ -247,7 +247,7 @@ class BinomialRng : public DistributionRng<int> {
 class PoissonRng : public DistributionRng<int> {
  public:
   PoissonRng(real_t mean);
-  virtual ~PoissonRng();
+  ~PoissonRng() override;
 
  private:
   real_t mean_;

--- a/src/core/visualization/paraview/adaptor.h
+++ b/src/core/visualization/paraview/adaptor.h
@@ -42,10 +42,10 @@ class ParaviewAdaptor : private VisualizationAdaptor {
   /// for the VTK grid structures
   ParaviewAdaptor();
 
-  ~ParaviewAdaptor();
+  ~ParaviewAdaptor() override;
 
   /// Visualize one timestep based on the configuration in `Param`
-  void Visualize();
+  void Visualize() override;
 
   struct ParaviewImpl;
 

--- a/src/core/visualization/paraview/mapped_data_array.h
+++ b/src/core/visualization/paraview/mapped_data_array.h
@@ -197,7 +197,7 @@ class MappedDataArray : public vtkMappedDataArray<TScalar>,
 
  protected:
   MappedDataArray();
-  ~MappedDataArray();
+  ~MappedDataArray() override;
 
   /// Access agent data member functor.
   GetDataMemberForVis<TScalar*, TClass, TDataMember> get_dm_;

--- a/src/neuroscience/neurite_element.h
+++ b/src/neuroscience/neurite_element.h
@@ -114,7 +114,7 @@ class NeuriteElement : public Agent, public NeuronOrNeurite {
 
   /// Returns StructureIdentifierSWC:kAxon if NeuriteElement is an Axon and
   /// StructureIdentifierSWC::kApicalDendrite for all other cases.
-  virtual StructureIdentifierSWC GetIdentifierSWC() const override;
+  StructureIdentifierSWC GetIdentifierSWC() const override;
 
   // TODO(neurites) arrange in order end
 

--- a/src/neuroscience/neuron_soma.h
+++ b/src/neuroscience/neuron_soma.h
@@ -32,7 +32,7 @@ class NeuronSoma : public Cell, public NeuronOrNeurite {
 
  public:
   NeuronSoma();
-  virtual ~NeuronSoma();
+  ~NeuronSoma() override;
 
   explicit NeuronSoma(const Real3& position);
 

--- a/src/neuroscience/new_agent_event/neurite_bifurcation_event.h
+++ b/src/neuroscience/new_agent_event/neurite_bifurcation_event.h
@@ -40,7 +40,7 @@ struct NeuriteBifurcationEvent : public NewAgentEvent {
         direction_left(direction_l),
         direction_right(direction_r) {}
 
-  virtual ~NeuriteBifurcationEvent() = default;
+  ~NeuriteBifurcationEvent() override = default;
 
   NewAgentEventUid GetUid() const override { return kUid; }
 

--- a/src/neuroscience/new_agent_event/neurite_branching_event.h
+++ b/src/neuroscience/new_agent_event/neurite_branching_event.h
@@ -38,7 +38,7 @@ struct NeuriteBranchingEvent : public NewAgentEvent {
         diameter(diameter),
         direction(direction) {}
 
-  virtual ~NeuriteBranchingEvent() = default;
+  ~NeuriteBranchingEvent() override = default;
 
   NewAgentEventUid GetUid() const override { return kUid; }
 

--- a/src/neuroscience/new_agent_event/new_neurite_extension_event.h
+++ b/src/neuroscience/new_agent_event/new_neurite_extension_event.h
@@ -30,7 +30,7 @@ struct NewNeuriteExtensionEvent : public NewAgentEvent {
   NewNeuriteExtensionEvent(real_t diameter, real_t phi, real_t theta)
       : diameter(diameter), phi(phi), theta(theta) {}
 
-  virtual ~NewNeuriteExtensionEvent() = default;
+  ~NewNeuriteExtensionEvent() override = default;
 
   NewAgentEventUid GetUid() const override { return kUid; }
 

--- a/src/neuroscience/new_agent_event/side_neurite_extension_event.h
+++ b/src/neuroscience/new_agent_event/side_neurite_extension_event.h
@@ -31,7 +31,7 @@ struct SideNeuriteExtensionEvent : public NewAgentEvent {
                             const Real3 direction)
       : length(length), diameter(diameter), direction(direction) {}
 
-  virtual ~SideNeuriteExtensionEvent() = default;
+  ~SideNeuriteExtensionEvent() override = default;
 
   NewAgentEventUid GetUid() const override { return kUid; }
 

--- a/src/neuroscience/new_agent_event/split_neurite_element_event.h
+++ b/src/neuroscience/new_agent_event/split_neurite_element_event.h
@@ -31,7 +31,7 @@ struct SplitNeuriteElementEvent : public NewAgentEvent {
   explicit SplitNeuriteElementEvent(real_t distal_portion)
       : distal_portion(distal_portion) {}
 
-  virtual ~SplitNeuriteElementEvent() = default;
+  ~SplitNeuriteElementEvent() override = default;
 
   NewAgentEventUid GetUid() const override { return kUid; }
 


### PR DESCRIPTION
Addresses the following code smells: https://sonarcloud.io/project/issues?resolved=false&rules=cpp%3AS3471&types=CODE_SMELL&id=BioDynaMo_biodynamo&open=AX7_qOQL2mRjajNH5Tw0

* [S3471](https://sonarcloud.io/organizations/biodynamo/rules?open=cpp%3AS3471&rule_key=cpp%3AS3471)
* [C++ core guidlines C.128](https://github.com/isocpp/CppCoreGuidelines/blob/036324/CppCoreGuidelines.md#c128-virtual-functions-should-specify-exactly-one-of-virtual-override-or-final)
