### PR TITLE
Param update

### DIFF
--- a/src/core/param/param.cc
+++ b/src/core/param/param.cc
@@ -227,6 +227,8 @@ void Param::AssignFromConfig(const std::shared_ptr<cpptoml::table>& config) {
   // simulation parameters group
   BDM_ASSIGN_CONFIG_VALUE(random_seed, "simulation.random_seed");
   BDM_ASSIGN_CONFIG_VALUE(output_dir, "simulation.output_dir");
+  BDM_ASSIGN_CONFIG_VALUE(remove_output_dir_contents,
+                          "simulation.remove_output_dir");
   BDM_ASSIGN_CONFIG_VALUE(environment, "simulation.environment");
   BDM_ASSIGN_CONFIG_VALUE(nanoflann_depth, "simulation.nanoflann_depth");
   BDM_ASSIGN_CONFIG_VALUE(unibn_bucketsize, "simulation.unibn_bucketsize");
@@ -250,17 +252,21 @@ void Param::AssignFromConfig(const std::shared_ptr<cpptoml::table>& config) {
   // visualization parameters group
   BDM_ASSIGN_CONFIG_VALUE(visualization_engine, "visualization.adaptor");
   BDM_ASSIGN_CONFIG_VALUE(insitu_visualization, "visualization.insitu");
-  BDM_ASSIGN_CONFIG_VALUE(pv_insitu_pipeline,
-                          "visualization.pv_insitu_pipeline");
-  BDM_ASSIGN_CONFIG_VALUE(pv_insitu_pipelinearguments,
-                          "visualization.pv_insitu_pipelinearguments");
+  if ("paraview"==visualization_engine) {
+    BDM_ASSIGN_CONFIG_VALUE(pv_insitu_pipeline,
+                            "visualization.pv_insitu_pipeline");
+    BDM_ASSIGN_CONFIG_VALUE(pv_insitu_pipelinearguments,
+                            "visualization.pv_insitu_pipelinearguments");
+  }
   BDM_ASSIGN_CONFIG_VALUE(root_visualization, "visualization.root");
   BDM_ASSIGN_CONFIG_VALUE(export_visualization, "visualization.export");
   BDM_ASSIGN_CONFIG_VALUE(visualization_interval, "visualization.interval");
-  BDM_ASSIGN_CONFIG_VALUE(visualization_export_generate_pvsm,
-                          "visualization.export_generate_pvsm");
-  BDM_ASSIGN_CONFIG_VALUE(visualization_compress_pv_files,
-                          "visualization.compress_pv_files");
+  if ("paraview"==visualization_engine) {
+    BDM_ASSIGN_CONFIG_VALUE(visualization_export_generate_pvsm,
+                            "visualization.export_generate_pvsm");
+    BDM_ASSIGN_CONFIG_VALUE(visualization_compress_pv_files,
+                            "visualization.compress_pv_files");
+  }
 
   // visualization parameters group (for agents)
   auto visualize_agentstarr = config->get_table_array("visualize_agent");
@@ -361,11 +367,16 @@ void Param::AssignFromConfig(const std::shared_ptr<cpptoml::table>& config) {
   BDM_ASSIGN_CONFIG_VALUE(show_simulation_step,
                           "development.show_simulation_step");
   BDM_ASSIGN_CONFIG_VALUE(use_progress_bar, "development.use_progress_bar");
+  if (use_progress_bar) {
+    BDM_ASSIGN_CONFIG_VALUE(progress_bar_time_unit,
+                            "development.progress_bar_time_unit");
+  }
 
   // experimental parameters group
   BDM_ASSIGN_CONFIG_VALUE(compute_target, "experimental.compute_target");
   BDM_ASSIGN_CONFIG_VALUE(opencl_debug, "experimental.opencl_debug");
   BDM_ASSIGN_CONFIG_VALUE(preferred_gpu, "experimental.preferred_gpu");
+  BDM_ASSIGN_CONFIG_VALUE(plot_memory_layout, "experimental.plot_memory_layout");
 }
 
 }  // namespace bdm

--- a/src/core/param/param.cc
+++ b/src/core/param/param.cc
@@ -252,7 +252,7 @@ void Param::AssignFromConfig(const std::shared_ptr<cpptoml::table>& config) {
   // visualization parameters group
   BDM_ASSIGN_CONFIG_VALUE(visualization_engine, "visualization.adaptor");
   BDM_ASSIGN_CONFIG_VALUE(insitu_visualization, "visualization.insitu");
-  if ("paraview"==visualization_engine) {
+  if ("paraview" == visualization_engine) {
     BDM_ASSIGN_CONFIG_VALUE(pv_insitu_pipeline,
                             "visualization.pv_insitu_pipeline");
     BDM_ASSIGN_CONFIG_VALUE(pv_insitu_pipelinearguments,
@@ -261,7 +261,7 @@ void Param::AssignFromConfig(const std::shared_ptr<cpptoml::table>& config) {
   BDM_ASSIGN_CONFIG_VALUE(root_visualization, "visualization.root");
   BDM_ASSIGN_CONFIG_VALUE(export_visualization, "visualization.export");
   BDM_ASSIGN_CONFIG_VALUE(visualization_interval, "visualization.interval");
-  if ("paraview"==visualization_engine) {
+  if ("paraview" == visualization_engine) {
     BDM_ASSIGN_CONFIG_VALUE(visualization_export_generate_pvsm,
                             "visualization.export_generate_pvsm");
     BDM_ASSIGN_CONFIG_VALUE(visualization_compress_pv_files,
@@ -376,7 +376,8 @@ void Param::AssignFromConfig(const std::shared_ptr<cpptoml::table>& config) {
   BDM_ASSIGN_CONFIG_VALUE(compute_target, "experimental.compute_target");
   BDM_ASSIGN_CONFIG_VALUE(opencl_debug, "experimental.opencl_debug");
   BDM_ASSIGN_CONFIG_VALUE(preferred_gpu, "experimental.preferred_gpu");
-  BDM_ASSIGN_CONFIG_VALUE(plot_memory_layout, "experimental.plot_memory_layout");
+  BDM_ASSIGN_CONFIG_VALUE(plot_memory_layout,
+                          "experimental.plot_memory_layout");
 }
 
 }  // namespace bdm

--- a/src/core/param/param.cc
+++ b/src/core/param/param.cc
@@ -62,6 +62,7 @@ void Param::Restore(Param&& other) {
   other.groups_.clear();
 }
 
+// -----------------------------------------------------------------------------
 Param::Param(const Param& other) {
   *this = other;
   for (auto el : other.groups_) {
@@ -223,7 +224,7 @@ void Param::AssignFromConfig(const std::shared_ptr<cpptoml::table>& config) {
     el.second->AssignFromConfig(config);
   }
 
-  // simulation group
+  // simulation parameters group
   BDM_ASSIGN_CONFIG_VALUE(random_seed, "simulation.random_seed");
   BDM_ASSIGN_CONFIG_VALUE(output_dir, "simulation.output_dir");
   BDM_ASSIGN_CONFIG_VALUE(environment, "simulation.environment");
@@ -242,10 +243,11 @@ void Param::AssignFromConfig(const std::shared_ptr<cpptoml::table>& config) {
   BDM_ASSIGN_CONFIG_VALUE(diffusion_method, "simulation.diffusion_method");
   BDM_ASSIGN_CONFIG_VALUE(calculate_gradients,
                           "simulation.calculate_gradients");
+
   AssignBoundSpaceMode(config, this);
   AssignThreadSafetyMechanism(config, this);
 
-  // visualization group
+  // visualization parameters group
   BDM_ASSIGN_CONFIG_VALUE(visualization_engine, "visualization.adaptor");
   BDM_ASSIGN_CONFIG_VALUE(insitu_visualization, "visualization.insitu");
   BDM_ASSIGN_CONFIG_VALUE(pv_insitu_pipeline,
@@ -260,7 +262,7 @@ void Param::AssignFromConfig(const std::shared_ptr<cpptoml::table>& config) {
   BDM_ASSIGN_CONFIG_VALUE(visualization_compress_pv_files,
                           "visualization.compress_pv_files");
 
-  //   visualize_agents
+  // visualization parameters group (for agents)
   auto visualize_agentstarr = config->get_table_array("visualize_agent");
   if (visualize_agentstarr) {
     for (const auto& table : *visualize_agentstarr) {
@@ -292,7 +294,7 @@ void Param::AssignFromConfig(const std::shared_ptr<cpptoml::table>& config) {
     }
   }
 
-  //   visualize_diffusion
+  // visualization parameters group (for diffusion grid)
   auto visualize_diffusiontarr = config->get_table_array("visualize_diffusion");
   if (visualize_diffusiontarr) {
     for (const auto& table : *visualize_diffusiontarr) {
@@ -335,7 +337,7 @@ void Param::AssignFromConfig(const std::shared_ptr<cpptoml::table>& config) {
     }
   }
 
-  // performance group
+  // performance parameters group
   BDM_ASSIGN_CONFIG_VALUE(scheduling_batch_size,
                           "performance.scheduling_batch_size");
   BDM_ASSIGN_CONFIG_VALUE(detect_static_agents,
@@ -350,16 +352,17 @@ void Param::AssignFromConfig(const std::shared_ptr<cpptoml::table>& config) {
                           "performance.mem_mgr_max_mem_per_thread_factor");
   BDM_ASSIGN_CONFIG_VALUE(minimize_memory_while_rebalancing,
                           "performance.minimize_memory_while_rebalancing");
+
   AssignMappedDataArrayMode(config, this);
 
-  // development group
+  // development parameters group
   BDM_ASSIGN_CONFIG_VALUE(statistics, "development.statistics");
   BDM_ASSIGN_CONFIG_VALUE(debug_numa, "development.debug_numa");
   BDM_ASSIGN_CONFIG_VALUE(show_simulation_step,
                           "development.show_simulation_step");
   BDM_ASSIGN_CONFIG_VALUE(use_progress_bar, "development.use_progress_bar");
 
-  // experimental group
+  // experimental parameters group
   BDM_ASSIGN_CONFIG_VALUE(compute_target, "experimental.compute_target");
   BDM_ASSIGN_CONFIG_VALUE(opencl_debug, "experimental.opencl_debug");
   BDM_ASSIGN_CONFIG_VALUE(preferred_gpu, "experimental.preferred_gpu");

--- a/src/core/param/param.h
+++ b/src/core/param/param.h
@@ -191,15 +191,6 @@ struct Param {
   ///     backup_interval = 1800
   uint32_t backup_interval = 1800;
 
-  /// Maximum jump that a point mass can do in one time step. Useful to
-  /// stabilize the simulation\n
-  /// Default value: `3.0`\n
-  /// TOML config file:
-  ///
-  ///     [simulation]
-  ///     max_displacement = 3.0
-  real_t simulation_max_displacement = 3.0;
-
   /// Enumarator to define about the simulation (off-lattice) domain
   /// where agents will reside.
   ///   `kOpen` : the simulation space grows to encapsulate all
@@ -229,22 +220,31 @@ struct Param {
   BoundSpaceMode bound_space = kOpen;
 
   /// Minimum allowed value for x-, y- and z-position if simulation space is
-  /// bound (@see `bound_space`).\n
-  /// Default value: `0`\n
+  /// bound (@see `bound_space`). Dimensionless parameter!
+  /// Default value: `-50`\n
   /// TOML config file:
   ///
   ///     [simulation]
-  ///     min_bound = 0
-  real_t min_bound = 0;
+  ///     min_bound = -50.0
+  real_t min_bound = -50.0;
 
   /// Maximum allowed value for x-, y- and z-position if simulation space is
-  /// bound (@see `bound_space`).\n
-  /// Default value: `100`\n
+  /// bound (@see `bound_space`). Dimensionless parameter!
+  /// Default value: `+50.`\n
   /// TOML config file:
   ///
   ///     [simulation]
-  ///     max_bound = 100
-  real_t max_bound = 100;
+  ///     max_bound = +50.0
+  real_t max_bound = +50.0;
+
+  /// Maximum jump that a point mass can do in one time step. Useful to
+  /// stabilize the simulation. Dimensionless parameter!
+  /// Default value: `1.`\n
+  /// TOML config file:
+  ///
+  ///     [simulation]
+  ///     max_displacement = 1.0
+  real_t simulation_max_displacement = (max_bound-min_bound)/100;
 
   /// Time between two simulation steps. Dimensionless parameter!
   /// Default value: `1.`\n

--- a/src/core/param/param.h
+++ b/src/core/param/param.h
@@ -101,10 +101,7 @@ struct Param {
   std::vector<std::string> unschedule_default_operations;
 
   ///
-  enum NumericalODESolver {
-    kEuler = 1,
-    kRK4 = 2
-  };
+  enum NumericalODESolver { kEuler = 1, kRK4 = 2 };
 
   /// Numerical method used to solve tha partial differential equation of
   /// the diffusion grid. Permissible values are: `"Euler"`, `"RK4"`.
@@ -205,11 +202,7 @@ struct Param {
   ///              determined by parameters `min_bound` and
   ///              `max_bound`, where if an agent moves outside the
   ///              cube then it is inserted on the opposite side.
-  enum BoundSpaceMode {
-    kOpen = 0,
-    kClosed,
-    kTorus
-  };
+  enum BoundSpaceMode { kOpen = 0, kClosed, kTorus };
 
   /// For this parameter definition \see `BoundSpaceMode`.
   /// Default value: `open` (simulation space is "infinite")\n
@@ -244,7 +237,7 @@ struct Param {
   ///
   ///     [simulation]
   ///     max_displacement = 1.0
-  real_t simulation_max_displacement = (max_bound-min_bound)/100;
+  real_t simulation_max_displacement = (max_bound - min_bound) / 100;
 
   /// Time between two simulation steps. Dimensionless parameter!
   /// Default value: `1.`\n
@@ -289,11 +282,7 @@ struct Param {
   ///                   processed in parallel. \see `Agent::CriticalRegion`.
   /// `kAutomatic`: the simulation automatically locks all agents of the
   ///               microenvironment.
-  enum ThreadSafetyMechanism {
-    kNone = 0,
-    kUserSpecified,
-    kAutomatic
-  };
+  enum ThreadSafetyMechanism { kNone = 0, kUserSpecified, kAutomatic };
 
   /// Select the thread-safety mechanism. Permissible values are:
   /// `"none"`, `"user-specified"`, `"automatic"`.
@@ -470,10 +459,7 @@ struct Param {
   uint64_t scheduling_batch_size = 1000;
 
   /// Enumerator to define order of computations agents-to-operations.
-  enum ExecutionOrder {
-    kForEachAgentForEachOp = 0,
-    kForEachOpForEachAgent
-  };
+  enum ExecutionOrder { kForEachAgentForEachOp = 0, kForEachOpForEachAgent };
 
   /// This parameter determines whether to execute for example either
   /// `kForEachAgentForEachOp`, meaning
@@ -578,11 +564,7 @@ struct Param {
   ///             array, to speed up access if it is used again.
   ///   `kCopy`: copy all data elements to a contiguous array at
   ///            initialization time. Serves requests from the cache.
-  enum MappedDataArrayMode {
-    kZeroCopy = 0,
-    kCopy,
-    kCache
-  };
+  enum MappedDataArrayMode { kZeroCopy = 0, kCopy, kCache };
 
   /// This parameter sets the operation mode in `bdm::MappedDataArray` with
   /// allowed values are defined in `MappedDataArrayMode`. Permissible values

--- a/src/core/param/param.h
+++ b/src/core/param/param.h
@@ -191,14 +191,6 @@ struct Param {
   ///     backup_interval = 1800
   uint32_t backup_interval = 1800;
 
-  /// Time between two simulation steps, in hours.
-  /// Default value: `0.01`\n
-  /// TOML config file:
-  ///
-  ///     [simulation]
-  ///     time_step = 0.0125
-  real_t simulation_time_step = 0.01;
-
   /// Maximum jump that a point mass can do in one time step. Useful to
   /// stabilize the simulation\n
   /// Default value: `3.0`\n
@@ -254,6 +246,13 @@ struct Param {
   ///     max_bound = 100
   real_t max_bound = 100;
 
+  /// Time between two simulation steps. Dimensionless parameter!
+  /// Default value: `1.`\n
+  /// TOML config file:
+  ///
+  ///     [simulation]
+  ///     time_step = 1.0
+  real_t simulation_time_step = 1.0;
 
   /// Define the boundary condition for the boundary-value problem of
   /// the diffusion grid. Permissible values are: `"open"`, `"closed"`,

--- a/src/core/param/param.h
+++ b/src/core/param/param.h
@@ -156,6 +156,11 @@ struct Param {
   /// organizes your simulation outputs in additional subfolders labelled with
   /// the date-time of your simulation `YYYY-MM-DD-HH:MM:SS`. Note that you will
   /// inevitably use more disk space with this option.
+  /// Default value: `true`\n
+  /// TOML config file:
+  ///
+  ///     [simulation]
+  ///     remove_output_dir = true
   bool remove_output_dir_contents = true;
 
   /// Backup file name for full simulation backups. The path is relative
@@ -696,6 +701,11 @@ struct Param {
 
   /// Determines if agents' memory layout plots should be generated
   /// during load balancing.
+  /// Default value: `false`\n
+  /// TOML config file:
+  ///
+  ///     [experimental]
+  ///     plot_memory_layout = false
   bool plot_memory_layout = false;
 
   // ---------------------------------------------------------------------------

--- a/src/core/param/param.h
+++ b/src/core/param/param.h
@@ -77,10 +77,12 @@ struct Param {
     }
   }
 
-  // simulation values ---------------------------------------------------------
-  /// Set random number seed.\n
-  /// The pseudo random number generator (prng) of each thread will be
-  /// initialized as follows:
+  // ---------------------------------------------------------------------------
+  // simulation parameters group : start
+  // ---------------------------------------------------------------------------
+
+  /// Set random number seed; the pseudo random number generator (prng)
+  /// of each thread will be initialized as follows:
   /// `prng[tid].SetSeed(random_seed * (tid + 1));`\n
   /// Default value: `4357`\n
   /// TOML config file:
@@ -89,22 +91,28 @@ struct Param {
   ///     random_seed = 4357
   uint64_t random_seed = 4357;
 
-  /// List of default operation names that should not be scheduled by default
+  /// List of default operation names that should not be scheduled by default.
   /// Default value: `{}`\n
   /// TOML config file:
   ///
   ///     [simulation]
-  ///     unschedule_default_operations = ["mechanical forces", "load
-  ///     balancing"]
+  ///     unschedule_default_operations =
+  ///       ["mechanical forces", "load balancing"]
   std::vector<std::string> unschedule_default_operations;
 
-  /// Variable which specifies method using for solving differential equation
-  /// {"Euler", "RK4"}.
-  enum NumericalODESolver { kEuler = 1, kRK4 = 2 };
+  ///
+  enum NumericalODESolver {
+    kEuler = 1,
+    kRK4 = 2
+  };
+
+  /// Numerical method used to solve tha partial differential equation of
+  /// the diffusion grid. Permissible values are: `"Euler"`, `"RK4"`.
+  /// Default value: `kEuler`\n
   NumericalODESolver numerical_ode_solver = NumericalODESolver::kEuler;
 
-  /// Output Directory name used to store visualization and other files.\n
-  /// Path is relative to working directory.\n
+  /// Output directory title to store all visualization and other files of
+  /// the simulation. The path is relative to the working directory.
   /// Default value: `"output"`\n
   /// TOML config file:
   ///
@@ -113,8 +121,8 @@ struct Param {
   std::string output_dir = "output";
 
   /// The method used to query the environment of a simulation object.
+  /// Permissible values are: `"uniform_grid"`, `"kd_tree"`, `"octree"`.
   /// Default value: `"uniform_grid"`\n
-  /// Other allowed values: `"kd_tree", "octree"`\n
   /// TOML config file:
   ///
   ///     [simulation]
@@ -123,7 +131,8 @@ struct Param {
 
   /// The depth of the kd tree if it's set as the environment (see
   /// Param::environment). For more information see:
-  /// https://github.com/jlblancoc/nanoflann\n
+  /// https://github.com/jlblancoc/nanoflann \n
+  /// Default value: `10`\n
   /// TOML config file:
   ///
   ///     [simulation]
@@ -133,6 +142,7 @@ struct Param {
   /// The bucket size of the octree if it's set as the environment (see
   /// Param::environment). For more information see:
   /// https://github.com/jbehley/octree
+  /// Default value: `16`\n
   /// TOML config file:
   ///
   ///     [simulation]
@@ -148,32 +158,32 @@ struct Param {
   /// inevitably use more disk space with this option.
   bool remove_output_dir_contents = true;
 
-  /// Backup file name for full simulation backups\n
-  /// Path is relative to working directory.\n
-  /// Default value: `""` (no backups will be made)\n
+  /// Backup file name for full simulation backups. The path is relative
+  /// to the working directory.
+  /// Default value: `""` (no backups will be saved)\n
+  /// Command line argument: `-b, --backup`
   /// TOML config file:
   ///
   ///     [simulation]
   ///     backup_file = <path>/<filename>.root
-  /// Command line argument: `-b, --backup`
   std::string backup_file = "";
 
-  /// File name to restore simulation from\n
-  /// Path is relative to working directory.\n
-  /// Default value: `""` (no restore will be made)\n
+  /// File name to restore simulation results. The path is relative
+  /// to working directory.
+  /// Default value: `""` (no restore files will be created)\n
+  /// Command line argument: `-r, --restore`
   /// TOML config file:
   ///
   ///     [simulation]
   ///     restore_file = <path>/<filename>.root
-  /// Command line argument: `-r, --restore`
   std::string restore_file = "";
 
   /// Specifies the interval (in seconds) in which backups will be performed.\n
-  /// Default Value: `1800` (every half an hour)\n
+  /// Default Value: `1800` (every half an hour).\n
   /// TOML config file:
   ///
   ///     [simulation]
-  ///     backup_interval = 1800  # backup every half an hour
+  ///     backup_interval = 1800
   uint32_t backup_interval = 1800;
 
   /// Time between two simulation steps, in hours.
@@ -193,24 +203,28 @@ struct Param {
   ///     max_displacement = 3.0
   real_t simulation_max_displacement = 3.0;
 
+  /// Enumarator to define about the simulation (off-lattice) domain
+  /// where agents will reside.
+  ///   `kOpen` : the simulation space grows to encapsulate all
+  ///             agents as the simulation progresses.
+  ///   `kClosed` :  enforce an artificial cubic bound around the
+  ///                simulation space; the dimensions of this cube
+  ///                are determined by parameters `min_bound` and
+  ///                `max_bound`, where if an agent moves outside the
+  ///                cube then it is pushed back in.
+  ///   `kTorus` : enforce an artificial cubic bound around the
+  ///              simulation space; the dimensions of this cube are
+  ///              determined by parameters `min_bound` and
+  ///              `max_bound`, where if an agent moves outside the
+  ///              cube then it is inserted on the opposite side.
   enum BoundSpaceMode {
-    /// The simulation space grows to encapsulate all agents.
     kOpen = 0,
-    /// Enforce an artificial cubic bound around the simulation space.
-    /// The dimensions of this cube are determined by parameter
-    /// `min_bound` and `max_bound`.\n
-    /// If agents move outside the cube they are moved back inside.
     kClosed,
-    /// Enforce an artificial cubic bound around the simulation space.
-    /// The dimensions of this cube are determined by parameter
-    /// `min_bound` and `max_bound`.\n
-    /// Agents that move outside the cube are moved back in on the opposite
-    /// side.
     kTorus
   };
 
+  /// For this parameter definition \see `BoundSpaceMode`.
   /// Default value: `open` (simulation space is "infinite")\n
-  /// \see BoundSpaceMode
   /// TOML config file:
   ///
   ///     [simulation]
@@ -235,45 +249,50 @@ struct Param {
   ///     max_bound = 100
   real_t max_bound = 100;
 
-  /// Define the boundary condition of the diffusion grid [open, closed,
-  /// Neumann, Dirichlet]\n
-  /// Default value: `"Neumann"`\n TOML config file:
+
+  /// Define the boundary condition for the boundary-value problem of
+  /// the diffusion grid. Permissible values are: `"open"`, `"closed"`,
+  /// `"Neumann"`, `"Dirichlet"`.
+  /// Default value: `"Neumann"`\n
+  /// TOML config file:
   ///
   ///     [simulation]
   ///     diffusion_boundary_condition = "Neumann"
   std::string diffusion_boundary_condition = "Neumann";
 
   /// A string for determining diffusion type within the simulation space.
-  /// Currently, only the method "euler" implementing a FTCS scheme is
+  /// Currently, only the method `"euler"` implementing a FTCS scheme is
   /// supported. See for instance here:
   /// https://en.wikipedia.org/wiki/FTCS_scheme (accessed 2023-07-17)
-  /// Default value: `"euler"`\n TOML
-  /// config file:
+  /// Default value: `"euler"`\n
+  /// TOML config file:
   ///
-  ///        [simulation]
-  ///        diffusion_method = <diffusion method>
-  ///
-
+  ///     [simulation]
+  ///     diffusion_method = <diffusion method>
   std::string diffusion_method = "euler";
 
-  /// Calculate the diffusion gradient for each substance.\n
-  /// TOML config file:
+  /// Calculate the gradient for each variable of the diffusion grid.
   /// Default value: `true`\n
+  /// TOML config file:
   ///
   ///     [simulation]
   ///     calculate_gradients = true
   bool calculate_gradients = true;
 
-  /// List of thread-safety mechanisms \n
-  /// `kNone`: \n
-  /// `kUserSpecified`: The user has to define all agent that must
-  /// not be processed in parallel. \see `Agent::CriticalRegion`.\n
-  /// `kAutomatic`: The simulation automatically locks all agents
-  /// of the microenvironment.
-  enum ThreadSafetyMechanism { kNone = 0, kUserSpecified, kAutomatic };
+  /// Enumerator to define about the list of thread-safety mechanisms.
+  /// `kNone`: .
+  /// `kUserSpecified`: the user has to define all agent that must not be
+  ///                   processed in parallel. \see `Agent::CriticalRegion`.
+  /// `kAutomatic`: the simulation automatically locks all agents of the
+  ///               microenvironment.
+  enum ThreadSafetyMechanism {
+    kNone = 0,
+    kUserSpecified,
+    kAutomatic
+  };
 
-  /// Select the thread-safety mechanism.\n
-  /// Possible values are: none, user-specified, automatic.\n
+  /// Select the thread-safety mechanism. Permissible values are:
+  /// `"none"`, `"user-specified"`, `"automatic"`.
   /// TOML config file:
   ///
   ///     [simulation]
@@ -281,10 +300,16 @@ struct Param {
   ThreadSafetyMechanism thread_safety_mechanism =
       ThreadSafetyMechanism::kUserSpecified;
 
-  // visualization values ------------------------------------------------------
+  // ---------------------------------------------------------------------------
+  // simulation parameters group : end
+  // ---------------------------------------------------------------------------
 
-  /// Name of the visualization engine to use for visualizaing BioDynaMo
-  /// simulations\n
+  // ---------------------------------------------------------------------------
+  // visualization parameters group : start
+  // ---------------------------------------------------------------------------
+
+  /// Name of the visualization engine to use for displaying the BioDynaMo
+  /// simulation results.
   /// Default value: `"paraview"`\n
   /// TOML config file:
   ///
@@ -292,10 +317,9 @@ struct Param {
   ///     adaptor = <name_of_adaptor>
   std::string visualization_engine = "paraview";
 
-  /// Use ParaView Catalyst for insitu visualization.\n
-  /// Insitu visualization supports live visualization
-  /// and rendering without writing files to the harddisk.\n
-  ///
+  /// Use ParaView Catalyst for on site (in-situ) visualization; such
+  /// visualization supports live display of the simulation results without
+  /// saving any files to the hard-drive.
   /// Default value: `false`\n
   /// TOML config file:
   ///
@@ -303,7 +327,7 @@ struct Param {
   ///     insitu = false
   bool insitu_visualization = false;
 
-  /// Write data to file for post-simulation visualization
+  /// Boolean to indicate if to save data for post-simulation visualization.
   /// Default value: `false`\n
   /// TOML config file:
   ///
@@ -311,7 +335,7 @@ struct Param {
   ///     export = false
   bool export_visualization = false;
 
-  /// Use ROOT for enable visualization.\n
+  /// Boolean to indicate if to use ROOT for data output.
   /// Default value: `false`\n
   /// TOML config file:
   ///
@@ -323,19 +347,19 @@ struct Param {
   /// Default value:
   /// `"<path-to-bdm>/include/core/visualization/paraview/default_insitu_pipeline.py"`\n
   /// TOML config file:
+  ///
   ///     [visualization]
   ///     pv_insitu_pipeline = ""
   std::string pv_insitu_pipeline =
       Concat(std::getenv("BDMSYS"),
              "/include/core/visualization/paraview/default_insitu_pipeline.py");
 
-  /// Arguments that will be passed to the python ParaView insitu pipeline
-  /// specified in `Param::pv_insitu_pipeline`.\n
-  /// The arguments will be passed to the ExtendDefaultPipeline function
+  /// Arguments that will be passed to the python ParaView in-situ pipeline
+  /// specified in `Param::pv_insitu_pipeline`. The arguments will be passed
+  /// to the ExtendDefaultPipeline function:
   /// `def ExtendDefaultPipeline(renderview, coprocessor, datadescription,
-  /// script_args):`
-  /// as fourth argument.\n
-  /// Default value: ""\n
+  /// script_args):` as fourth argument.
+  /// Default value: `""`\n
   /// TOML config file:
   ///
   ///     [visualization]
@@ -343,8 +367,8 @@ struct Param {
   std::string pv_insitu_pipelinearguments = "";
 
   /// If `export_visualization` is set to true, this parameter specifies
-  /// how often it should be exported. 1 = every timestep, 10: every 10
-  /// time steps.\n
+  /// how often it should be exported. 1 = every timestep, 10: every ten
+  /// time steps, and so on.
   /// Default value: `1`\n
   /// TOML config file:
   ///
@@ -353,7 +377,7 @@ struct Param {
   uint32_t visualization_interval = 1;
 
   /// If `export_visualization` is set to true, this parameter specifies
-  /// if the ParaView pvsm file will be generated!\n
+  /// if the ParaView pvsm file will be generated!
   /// Default value: `true`\n
   /// TOML config file:
   ///
@@ -361,13 +385,13 @@ struct Param {
   ///     export_generate_pvsm = true
   bool visualization_export_generate_pvsm = true;
 
-  /// Specifies which agents should be visualized. \n
+  /// Specifies which agents should be visualized.
   /// Every agent defines the minimum set of data members which
-  /// are required to visualize it. (e.g. Cell: `position_` and `diameter_`).\n
+  /// are required to visualize it (e.g. agent `position_` and `diameter_`).
   /// With this parameter it is also possible to extend the number of data
   /// members that are sent to the visualization engine.
+  /// NOTICE: This data member is not backed up, due to an error in ROOT.\n
   /// Default value: empty (no agent will be visualized)\n
-  /// NB: This data member is not backed up, due to a ROOT error.
   /// TOML config file:
   ///
   ///     [visualization]
@@ -415,20 +439,25 @@ struct Param {
   ///       # default values: concentration = true and gradient = false
   std::vector<VisualizeDiffusion> visualize_diffusion;
 
-  /// Specifies if the ParView files that are generated in export mode
-  /// should be compressed.\n
-  /// Default value: true\n
+  /// If to export simulation results files for visualization, this
+  /// parameter specifies if to compress output files for Paraview.
+  /// Default value: `true`\n
   /// TOML config file:
   ///
   ///     [visualization]
   ///     export = true
   ///     compress_pv_files = true
-  ///
   bool visualization_compress_pv_files = true;
 
-  // performance values --------------------------------------------------------
+  // ---------------------------------------------------------------------------
+  // visualization parameters group : end
+  // ---------------------------------------------------------------------------
 
-  /// Batch size used by the `Scheduler` to iterate over agents\n
+  // ---------------------------------------------------------------------------
+  // performance parameters group : start
+  // ---------------------------------------------------------------------------
+
+  /// Batch size used by the `Scheduler` to iterate over agents.
   /// Default value: `1000`\n
   /// TOML config file:
   ///
@@ -436,9 +465,14 @@ struct Param {
   ///     scheduling_batch_size = 1000
   uint64_t scheduling_batch_size = 1000;
 
-  enum ExecutionOrder { kForEachAgentForEachOp = 0, kForEachOpForEachAgent };
+  /// Enumerator to define order of computations agents-to-operations.
+  enum ExecutionOrder {
+    kForEachAgentForEachOp = 0,
+    kForEachOpForEachAgent
+  };
 
-  /// This parameter determines whether to execute  `kForEachAgentForEachOp`
+  /// This parameter determines whether to execute for example either
+  /// `kForEachAgentForEachOp`, meaning
   /// \code
   /// for (auto* agent : agents) {
   ///   for (auto* op : agent_ops) {
@@ -446,7 +480,7 @@ struct Param {
   ///   }
   /// }
   /// \endcode
-  /// or `kForEachOpForEachAgent`
+  /// or `kForEachOpForEachAgent`, which translates
   /// \code
   /// for (auto* op : agent_ops) {
   ///   for (auto* agent : agents) {
@@ -454,14 +488,15 @@ struct Param {
   ///   }
   /// }
   /// \endcode
+  /// Default value: `kForEachAgentForEachOp`\n
   ExecutionOrder execution_order = ExecutionOrder::kForEachAgentForEachOp;
 
   /// Calculation of the displacement (mechanical interaction) is an
-  /// expensive operation. If agents do not move or grow,
-  /// displacement calculation is omitted if detect_static_agents is turned
-  /// on. However, the detection mechanism introduces an overhead. For dynamic
+  /// expensive operation. If agents do not move or grow, displacement
+  /// calculation is omitted if detect_static_agents is turned on.
+  /// However, the detection mechanism introduces an overhead. For dynamic
   /// simulations where agents move and grow, the overhead outweighs the
-  /// benefits.\n
+  /// benefits.
   /// Default value: `false`\n
   /// TOML config file:
   ///
@@ -471,7 +506,7 @@ struct Param {
 
   /// Neighbors of an agent can be cached so to avoid consecutive
   /// searches. This of course only makes sense if there is more than one
-  /// `ForEachNeighbor*` operation.\n
+  /// `ForEachNeighbor*` operation.
   /// Default value: `false`\n
   /// TOML config file:
   ///
@@ -488,9 +523,8 @@ struct Param {
 
   /// The BioDynaMo memory manager allocates N page aligned memory blocks.
   /// The bigger N, the lower the memory overhead due to metadata storage
-  /// if a lot of memory is used.\n
-  /// N must be a number of two.\n
-  /// Therefore, this parameter specifies the shift for N. `N = 2 ^ shift`\n
+  /// if a lot of memory is used. N must be a number of two.
+  /// Therefore, this parameter specifies the shift for N: `N = 2 ^ shift`.
   /// Default value: `5` `-> N = 32`\n
   /// TOML config file:
   ///
@@ -500,7 +534,7 @@ struct Param {
 
   /// The BioDynaMo memory manager allocates memory in increasing sizes using
   /// a geometric series. This parameter specifies the growth rate.
-  /// Default value: `2.0`\n
+  /// Default value: `1.1`\n
   /// TOML config file:
   ///
   ///     [performance]
@@ -508,26 +542,25 @@ struct Param {
   real_t mem_mgr_growth_rate = 1.1;
 
   /// The BioDynaMo memory manager can migrate memory between thread pools
-  /// to avoid memory leaks.\n
-  /// This parameter influences the maximum memory size in bytes before
-  /// migration happens.\n
-  /// The size in bytes depends on the system's page size and the parameter
-  /// `mem_mgr_aligned_pages_shift` and is calculated as follows:
-  /// `PAGE_SIZE * 2 ^ mem_mgr_aligned_pages_shift *
-  /// mem_mgr_max_mem_per_thread_factor`\n Default value: `1`\n TOML config
-  /// file:
+  /// to avoid memory leaks. This parameter influences the maximum memory
+  /// size in bytes before migration happens. The size in bytes depends on
+  /// the system's page size and the parameter `mem_mgr_aligned_pages_shift`
+  /// and is calculated via: `PAGE_SIZE * 2 ^ mem_mgr_aligned_pages_shift *
+  /// mem_mgr_max_mem_per_thread_factor`.
+  /// Default value: `1`\n
+  /// TOML config file:
   ///
   ///     [performance]
   ///     mem_mgr_max_mem_per_thread_factor = 1
   uint64_t mem_mgr_max_mem_per_thread_factor = 1;
 
   /// This parameter is used inside `ResourceManager::LoadBalance`.
-  /// If it is set to true, the function will reuse existing memory to rebalance
-  /// agents to NUMA nodes. (A small amount of additional memory
-  /// is still required.)\n
-  /// If this parameter is set to false, the balancing function will first
-  /// create new objects and delete the old ones in a second step. In the worst
-  /// case this will real_t the required memory for agents for.
+  /// If it is set to `true`, the function will reuse existing memory to
+  /// rebalance agents to NUMA nodes. (A small amount of additional memory
+  /// is still required.)
+  /// If this parameter is set to `false`, the balancing function will first
+  /// create new objects and delete the old ones in a second step. In worst
+  /// case, this will `real_t` the required memory for agents for.
   /// Default value: `true`\n
   /// TOML config file:
   ///
@@ -536,17 +569,20 @@ struct Param {
   bool minimize_memory_while_rebalancing = true;
 
   /// MappedDataArrayMode options:
-  ///   `kZeroCopy`: access agent data directly only if it is
-  ///                requested. \n
-  ///   `kCache`:    Like `kZeroCopy` but stores the results in contiguous
-  ///                array, to speed up access if it is used again.\n
-  ///   `kCopy`:     Copy all data elements to a contiguous array at
-  ///                initialization time. Serves requests from the cache.
-  enum MappedDataArrayMode { kZeroCopy = 0, kCopy, kCache };
+  ///   `kZeroCopy`: access agent data directly only if it is requested.
+  ///   `kCache`: as in `kZeroCopy` but stores the results in contiguous
+  ///             array, to speed up access if it is used again.
+  ///   `kCopy`: copy all data elements to a contiguous array at
+  ///            initialization time. Serves requests from the cache.
+  enum MappedDataArrayMode {
+    kZeroCopy = 0,
+    kCopy,
+    kCache
+  };
 
-  /// This parameter sets the operation mode in `bdm::MappedDataArray`.\n
-  /// Allowed values are defined in `MappedDataArrayMode`\n
-  /// Possible values: zero-copy, cache, copy\n
+  /// This parameter sets the operation mode in `bdm::MappedDataArray` with
+  /// allowed values are defined in `MappedDataArrayMode`. Permissible values
+  /// are: `"zero-copy"`, `"cache"`, `"copy"`.
   /// Default value: `zero-copy`\n
   /// TOML config file:
   ///
@@ -555,11 +591,17 @@ struct Param {
   Param::MappedDataArrayMode mapped_data_array_mode =
       MappedDataArrayMode::kZeroCopy;
 
-  // development values --------------------------------------------------------
+  // ---------------------------------------------------------------------------
+  // performance parameters group : end
+  // ---------------------------------------------------------------------------
+
+  // ---------------------------------------------------------------------------
+  // development parameters group : start
+  // ---------------------------------------------------------------------------
+
   /// Statistics of profiling data; keeps track of the execution time of each
-  /// operation at every timestep.\n
-  /// If set to true it prints simulation data at the end of the simulation
-  /// to std::cout and a file.\n
+  /// operation at every timestep. If set to true it prints simulation data at
+  /// the end of the simulation to `std::cout` and a file.
   /// Default Value: `false`\n
   /// TOML config file:
   ///
@@ -570,14 +612,14 @@ struct Param {
   /// Automatically track changes in the simulation and BioDynaMo repository.
   /// If set to true, BioDynaMo scans the simulation directory and the BioDynaMo
   /// repository for changes and saves the information of the git repositories
-  /// in the output directory.\n
+  /// in the output directory.
   /// Default Value: `true`\n
 #ifdef USE_LIBGIT2
   bool track_git_changes = true;
 #endif  // USE_LIBGIT2
 
-  /// Output debugging info related to running on NUMA architecture.\n
-  /// \see `ThreadInfo`, `ResourceManager::DebugNuma`
+  /// Output debugging info related to running on NUMA architecture.
+  /// \see `ThreadInfo`, `ResourceManager::DebugNuma`.
   /// Default Value: `false`\n
   /// TOML config file:
   ///
@@ -586,10 +628,11 @@ struct Param {
   bool debug_numa = false;
 
   /// Display the simulation step in the terminal output with a defined
-  /// frequency.\nThe value `0` shows no output, a value of `1` prints all
-  /// steps, a value of `2` prints every second step, and so on.\n
+  /// frequency. The value `0` shows no output, a value of `1` prints all
+  /// steps, a value of `2` prints every two steps, and so on.
   /// Default value: `0`\n
   /// TOML config file:
+  ///
   ///     [development]
   ///     show_simulation_step = 0
   uint64_t show_simulation_step = 0;
@@ -602,40 +645,51 @@ struct Param {
   /// '\r' in its print statements.
   /// Default value: `false`\n
   /// TOML config file:
+  ///
   ///     [development]
   ///     use_progress_bar = false
   bool use_progress_bar = false;
 
-  /// Time unit of the progress bar. Possible values: "ms", "s", "min", "h"
+  /// Time unit of the progress bar. Permissible values are: `"ms"`, `"s"`,
+  /// `"min"`, `"h"`, `"d"`.
   /// Default value: `"s"`\n
   /// TOML config file:
+  ///
   ///     [development]
   ///     progress_bar_time_unit = "s"
   std::string progress_bar_time_unit = "s";
 
   // ---------------------------------------------------------------------------
-  // experimental group
+  // development parameters group : end
+  // ---------------------------------------------------------------------------
+
+  // ---------------------------------------------------------------------------
+  // experimental parameters group : start
+  // ---------------------------------------------------------------------------
 
   /// Run the simulation partially on the GPU for improved performance.
-  /// Possible values: "cpu", "cuda", "opencl"
+  /// Permissible values are: `"cpu"`, `"cuda"`, `"opencl"`.
   /// Default value: `"cpu"`\n
   /// TOML config file:
+  ///
   ///     [experimental]
-  ///     compute_target = false
+  ///     compute_target = "cpu"
   std::string compute_target = "cpu";
 
   /// Compile OpenCL kernels with debugging symbols, for debugging on CPU
   /// targets with GNU gdb.
   /// Default value: `false`\n
   /// TOML config file:
+  ///
   ///     [experimental]
   ///     opencl_debug = false
   bool opencl_debug = false;
 
   /// Set the index of the preferred GPU you wish to use. In GpuHelper we
-  /// set the default to whichever GPU supports double precision
-  /// Default value: `0`\n
+  /// set the default to whichever GPU supports double precision.
+  /// Default value: `-1`\n
   /// TOML config file:
+  ///
   ///     [experimental]
   ///     preferred_gpu = <GPU with double precision support>
   int preferred_gpu = -1;
@@ -643,6 +697,10 @@ struct Param {
   /// Determines if agents' memory layout plots should be generated
   /// during load balancing.
   bool plot_memory_layout = false;
+
+  // ---------------------------------------------------------------------------
+  // experimental parameters group : end
+  // ---------------------------------------------------------------------------
 
   /// Assign values from config file to variables
   void AssignFromConfig(const std::shared_ptr<cpptoml::table>&);

--- a/test/unit/neuroscience/mechanical_interaction_test.cc
+++ b/test/unit/neuroscience/mechanical_interaction_test.cc
@@ -107,7 +107,7 @@ void RunTest2(const char* test_name, bool detect_static_agents) {
 
   Real3 direction = {1, 0, 0};
   for (int i = 0; i < 100; i++) {
-    ne->ElongateTerminalEnd(100, direction);
+    ne->ElongateTerminalEnd(1, direction);
     scheduler->Simulate(1);
     if (i % 10 == 0) {
       ne_axis = ne->GetSpringAxis();

--- a/test/unit/neuroscience/neuron_soma_test.cc
+++ b/test/unit/neuroscience/neuron_soma_test.cc
@@ -145,7 +145,7 @@ TEST(NeuronSomaTest, ExtendNeuriteAndElongate) {
 
   // will create a new neurite segment at iteration 139
   for (int i = 0; i < 200; ++i) {
-    neurite_element->ElongateTerminalEnd(10, {0, 0, 1});
+    neurite_element->ElongateTerminalEnd(0.1, {0, 0, 1});
     neurite_element->RunDiscretization();
   }
 
@@ -212,14 +212,14 @@ TEST(NeuriteElementTest, PartialRetraction) {
 
   // will create a new neurite segment at iteration 139
   for (int i = 0; i < 200; ++i) {
-    neurite_element->ElongateTerminalEnd(10, {0, 0, 1});
+    neurite_element->ElongateTerminalEnd(0.1, {0, 0, 1});
     neurite_element->RunDiscretization();
   }
 
   // will remove the proximal segment
   for (int i = 0; i < 140; ++i) {
     ctxt->SetupIterationAll(simulation.GetAllExecCtxts());
-    neurite_element->RetractTerminalEnd(10);
+    neurite_element->RetractTerminalEnd(0.1);
     neurite_element->RunDiscretization();
     ctxt->TearDownIterationAll(simulation.GetAllExecCtxts());
   }


### PR DESCRIPTION
1. Improved a bit the wording and clarified some core parameters description.
2. Allowed a simulation and a development parameter to be read from the configuration file.
3. Reset the default value for the simulation time step to =1.
4. Reset the min/max bounds of the simulation domain so that it's centralised to origin (0,0,0).
5. Reset the max displacement parameter to 1% of the simulation domain size.