### PR TITLE
Terminate GHA when branch updates

### DIFF
--- a/.github/workflows/centos-ci.yml
+++ b/.github/workflows/centos-ci.yml
@@ -6,6 +6,10 @@ on:
     branches:
       - master
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/centos-system-ci.yml
+++ b/.github/workflows/centos-system-ci.yml
@@ -13,6 +13,10 @@ on:
     branches:
       - master
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -6,6 +6,10 @@ on:
     branches:
       - master
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     strategy:

--- a/.github/workflows/macos-system-ci.yml
+++ b/.github/workflows/macos-system-ci.yml
@@ -13,6 +13,10 @@ on:
     branches:
       - master
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     strategy:

--- a/.github/workflows/repostory-checks.yml
+++ b/.github/workflows/repostory-checks.yml
@@ -3,6 +3,10 @@ name: repository-check
 on:
   push:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   code-style:
     runs-on: ubuntu-20.04

--- a/.github/workflows/singularity-integration.yml
+++ b/.github/workflows/singularity-integration.yml
@@ -7,6 +7,10 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Build

--- a/.github/workflows/sonar-source.yml
+++ b/.github/workflows/sonar-source.yml
@@ -5,6 +5,11 @@ on:
       - master
   pull_request:
     types: [opened, synchronize, reopened]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Sonar Source Analysis

--- a/.github/workflows/ubuntu-ci.yml
+++ b/.github/workflows/ubuntu-ci.yml
@@ -6,6 +6,10 @@ on:
     branches:
       - master
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     strategy:

--- a/.github/workflows/ubuntu-system-ci.yml
+++ b/.github/workflows/ubuntu-system-ci.yml
@@ -13,6 +13,10 @@ on:
     branches:
       - master
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     strategy:


### PR DESCRIPTION
Add concurrency check to GHA. If you commit to the same branch quickly after each other, this will stop previously launched runs and avoid waiting for previous runs to finish or manually terminating them.