### PR TITLE
Deprecate `macOS` < 12.0 

### DIFF
--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -14,7 +14,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [macos-11, macos-12, macos-13]
+        os: [macos-12, macos-13]
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/macos-system-ci.yml
+++ b/.github/workflows/macos-system-ci.yml
@@ -21,7 +21,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [macos-11, macos-12, macos-13]
+        os: [macos-12, macos-13]
 
     runs-on: ${{ matrix.os }}
 

--- a/doc/user_guide/installation.md
+++ b/doc/user_guide/installation.md
@@ -61,7 +61,7 @@ curl https://biodynamo.github.io/install | bash
 
 *  Ubuntu 20.04, 22.04
 *  CentOS 7
-*  MacOS 11.7 and 12.6 (Intel and ARM)
+*  MacOS > 12.0 (Intel and ARM)
 
 Currently, we do **not** support Windows or Windows subsystem for Linux.
 

--- a/doc/user_guide/prerequisites.md
+++ b/doc/user_guide/prerequisites.md
@@ -219,7 +219,7 @@ sudo yum install -y llvm-toolset-7 llvm-toolset-7-clang-tools-extra \
 Requirements to build on macOS are:
 
  * A 64-bit Intel CPU or Apple Silicon CPU
- * macOS Catalina (10.15) or higher
+ * macOS 12.0 or higher
  * [Xcode](https://itunes.apple.com/us/app/xcode/id497799835) and the Command Line Tools (CLT) for Xcode: `xcode-select --install`  
     (or from [developer.apple.com/downloads](https://developer.apple.com/downloads))
  * An up to date [Homebrew](https://brew.sh) installation (MacPorts and Fink are not supported)


### PR DESCRIPTION
Our support for macOS is founded in the `brew` package manager. `brew` no longer supports macOS 11 and, thus, our macOS 11 CI currently fails. This PR removes support for macOS < 12.0. 

See https://github.com/orgs/Homebrew/discussions/4827#discussioncomment-7189632