### PR TITLE
Periodic boundaries

### DIFF
--- a/doc/user_guide/diffusion.md
+++ b/doc/user_guide/diffusion.md
@@ -143,7 +143,7 @@ Then click the Play button at the top of the screen to run the simulation visual
 ### Boundary conditions
 
 For a numerical solution, we need to specify the equation, the boundary
-conditions, and the domain. BioDynaMo supports Neumann and Dirichlet boundaries 
+conditions, and the domain. BioDynaMo supports Neumann, Dirichlet and Periodic boundaries 
 with constant coefficients on a cube domain. For instance, you may specify 
 no-flux boundaries (homogeneous Neumann) via
 ``` cpp
@@ -156,6 +156,11 @@ or some Dirichlet boundaries via
 ModelInitializer::AddBoundaryConditions(
     kKalium, BoundaryConditionType::kDirichlet,
     std::make_unique<ConstantBoundaryCondition>(1.0));
+```
+or Periodic boundaries via
+``` cpp
+ModelInitializer::AddBoundaryConditions(
+    kKalium, BoundaryConditionType::kPeriodic);
 ```
 
 The `ModelInitializer` conveniently wraps the access to the `ResourceManager`

--- a/src/core/diffusion/diffusion_grid.cc
+++ b/src/core/diffusion/diffusion_grid.cc
@@ -33,6 +33,8 @@ std::string BoundaryTypeToString(const BoundaryConditionType& type) {
       return "closed";
     case BoundaryConditionType::kDirichlet:
       return "Dirichlet";
+    case BoundaryConditionType::kPeriodic:
+      return "Periodic";
     default:
       return "unknown";
   }
@@ -48,6 +50,8 @@ BoundaryConditionType StringToBoundaryType(const std::string& type) {
     return BoundaryConditionType::kClosedBoundaries;
   } else if (type == "Dirichlet") {
     return BoundaryConditionType::kDirichlet;
+  } else if (type == "Periodic") {
+    return BoundaryConditionType::kPeriodic;
   } else {
     Log::Fatal("StringToBoundaryType", "Unknown boundary type: ", type);
     return BoundaryConditionType::kNeumann;
@@ -139,6 +143,8 @@ void DiffusionGrid::Diffuse(real_t dt) {
     DiffuseWithDirichlet(dt);
   } else if (bc_type_ == BoundaryConditionType::kNeumann) {
     DiffuseWithNeumann(dt);
+  } else if (bc_type_ == BoundaryConditionType::kPeriodic) {
+    DiffuseWithPeriodic(dt);
   } else {
     Log::Error(
         "EulerGrid::Diffuse", "Boundary condition of type '",

--- a/src/core/diffusion/diffusion_grid.h
+++ b/src/core/diffusion/diffusion_grid.h
@@ -36,7 +36,8 @@ enum class BoundaryConditionType {
   kDirichlet,
   kNeumann,
   kOpenBoundaries,
-  kClosedBoundaries
+  kClosedBoundaries,
+  kPeriodic
 };
 
 enum class InteractionMode { kAdditive = 0, kExponential = 1, kLogistic = 2 };
@@ -117,6 +118,9 @@ class DiffusionGrid : public ScalarField {
   /// Compute the diffusion of the substance with Neumann boundary conditions
   /// (du/dn = const on the boundary) for a given time step dt.
   virtual void DiffuseWithNeumann(real_t dt) = 0;
+  /// Compute the diffusion of the substance with Periodic boundary conditions
+  /// (u_{-1} = {u_N-1}, u_{N} = u_{0}) for a given time step dt.
+  virtual void DiffuseWithPeriodic(real_t dt) = 0;
 
   /// Calculates the gradient for each box in the diffusion grid.
   /// The gradient is calculated in each direction (x, y, z) as following:

--- a/src/core/diffusion/euler_depletion_grid.cc
+++ b/src/core/diffusion/euler_depletion_grid.cc
@@ -88,4 +88,11 @@ void EulerDepletionGrid::DiffuseWithNeumann(real_t dt) {
   ApplyDepletion(dt);
 }
 
+void EulerDepletionGrid::DiffuseWithPeriodic(real_t dt) {
+  // Update concentration without depletion (c1 is modified)
+  EulerGrid::DiffuseWithPeriodic(dt);
+
+  ApplyDepletion(dt);
+}
+
 }  // namespace bdm

--- a/src/core/diffusion/euler_depletion_grid.h
+++ b/src/core/diffusion/euler_depletion_grid.h
@@ -58,6 +58,10 @@ class EulerDepletionGrid : public EulerGrid {
   /// subsequently depletes the substance according to binding_substances_ and
   /// binding_coefficients_. See ApplyDepletion for details.
   void DiffuseWithNeumann(real_t dt) override;
+  /// Simulates the Diffusion with EulerGrid::DiffuseWithPeriodic and
+  /// subsequently depletes the substance according to binding_substances_ and
+  /// binding_coefficients_. See ApplyDepletion for details.
+  void DiffuseWithPeriodic(real_t dt) override;
 
   // To avoid missing substances or coefficients, name of the sub and binding
   // coefficient must be set at the same time

--- a/src/core/diffusion/euler_grid.cc
+++ b/src/core/diffusion/euler_grid.cc
@@ -247,8 +247,8 @@ void EulerGrid::DiffuseWithNeumann(real_t dt) {
           // Clamp to avoid out of bounds access. Clamped values are initialized
           // to a wrong value but will be overwritten by the boundary condition
           // evaluation. All other values are correct.
-          real_t left{c1_[std::clamp(l, size_t{0}, num_boxes - 1)]};
-          real_t right{c1_[std::clamp(r, size_t{0}, num_boxes - 1)]};
+          real_t left{c1_[std::clamp(c-1, size_t{0}, num_boxes - 1)]};
+          real_t right{c1_[std::clamp(c+1, size_t{0}, num_boxes - 1)]};
           real_t bottom{c1_[std::clamp(b, size_t{0}, num_boxes - 1)]};
           real_t top{c1_[std::clamp(t, size_t{0}, num_boxes - 1)]};
           real_t north{c1_[std::clamp(n, size_t{0}, num_boxes - 1)]};

--- a/src/core/diffusion/euler_grid.cc
+++ b/src/core/diffusion/euler_grid.cc
@@ -18,18 +18,6 @@
 
 namespace bdm {
 
-// Function to move <val> into the range [<min>, <max>]. If it is in the range
-// already, it is returned unchanged. Else, the closest boundary is returned.
-inline size_t Clamp(size_t val, size_t min, size_t max) {
-  if (val < min) {
-    return min;
-  }
-  if (val > max) {
-    return max;
-  }
-  return val;
-}
-
 void EulerGrid::DiffuseWithClosedEdge(real_t dt) {
   const auto nx = resolution_;
   const auto ny = resolution_;
@@ -223,10 +211,10 @@ void EulerGrid::DiffuseWithDirichlet(real_t dt) {
 }
 
 void EulerGrid::DiffuseWithNeumann(real_t dt) {
-  const auto nx = resolution_;
-  const auto ny = resolution_;
-  const auto nz = resolution_;
-  const auto num_boxes = nx * ny * nz;
+  const size_t nx = resolution_;
+  const size_t ny = resolution_;
+  const size_t nz = resolution_;
+  const size_t num_boxes = nx * ny * nz;
 
   const real_t ibl2 = 1 / (box_length_ * box_length_);
   const real_t d = 1 - dc_[0];
@@ -259,12 +247,12 @@ void EulerGrid::DiffuseWithNeumann(real_t dt) {
           // Clamp to avoid out of bounds access. Clamped values are initialized
           // to a wrong value but will be overwritten by the boundary condition
           // evaluation. All other values are correct.
-          real_t left{c1_[Clamp(c - 1, 0, num_boxes - 1)]};
-          real_t right{c1_[Clamp(c + 1, 0, num_boxes - 1)]};
-          real_t bottom{c1_[Clamp(b, 0, num_boxes - 1)]};
-          real_t top{c1_[Clamp(t, 0, num_boxes - 1)]};
-          real_t north{c1_[Clamp(n, 0, num_boxes - 1)]};
-          real_t south{c1_[Clamp(s, 0, num_boxes - 1)]};
+          real_t left{c1_[std::clamp(c - 1, size_t{0}, num_boxes - 1)]};
+          real_t right{c1_[std::clamp(c + 1, size_t{0}, num_boxes - 1)]};
+          real_t bottom{c1_[std::clamp(b, size_t{0}, num_boxes - 1)]};
+          real_t top{c1_[std::clamp(t, size_t{0}, num_boxes - 1)]};
+          real_t north{c1_[std::clamp(n, size_t{0}, num_boxes - 1)]};
+          real_t south{c1_[std::clamp(s, size_t{0}, num_boxes - 1)]};
           real_t center_factor{6.0};
 
           if (x == 0 || x == (nx - 1) || y == 0 || y == (ny - 1) || z == 0 ||
@@ -315,10 +303,10 @@ void EulerGrid::DiffuseWithNeumann(real_t dt) {
 
 void EulerGrid::DiffuseWithPeriodic(real_t dt) {
 
-  const auto nx = resolution_;
-  const auto ny = resolution_;
-  const auto nz = resolution_;
-  const auto num_boxes = nx * ny * nz;
+  const size_t nx = resolution_;
+  const size_t ny = resolution_;
+  const size_t nz = resolution_;
+  const size_t num_boxes = nx * ny * nz;
 
   const real_t dx = box_length_;
   const real_t d = 1 - dc_[0];
@@ -353,12 +341,12 @@ void EulerGrid::DiffuseWithPeriodic(real_t dt) {
           // Clamp to avoid out of bounds access. Clamped values are initialized
           // to a wrong value but will be overwritten by the boundary condition
           // evaluation. All other values are correct.
-          real_t left{c1_[std::clamp(l, 0, num_boxes - 1)]};
-          real_t right{c1_[std::clamp(r, 0, num_boxes - 1)]};
-          real_t bottom{c1_[std::clamp(b, 0, num_boxes - 1)]};
-          real_t top{c1_[std::clamp(t, 0, num_boxes - 1)]};
-          real_t north{c1_[std::clamp(n, 0, num_boxes - 1)]};
-          real_t south{c1_[std::clamp(s, 0, num_boxes - 1)]};
+          real_t left{c1_[std::clamp(l, size_t{0}, num_boxes - 1)]};
+          real_t right{c1_[std::clamp(r, size_t{0}, num_boxes - 1)]};
+          real_t bottom{c1_[std::clamp(b, size_t{0}, num_boxes - 1)]};
+          real_t top{c1_[std::clamp(t, size_t{0}, num_boxes - 1)]};
+          real_t north{c1_[std::clamp(n, size_t{0}, num_boxes - 1)]};
+          real_t south{c1_[std::clamp(s, size_t{0}, num_boxes - 1)]};
 
           if (x == 0 || x == (nx - 1) || y == 0 || y == (ny - 1) || z == 0 ||
               z == (nz - 1)) {

--- a/src/core/diffusion/euler_grid.cc
+++ b/src/core/diffusion/euler_grid.cc
@@ -247,8 +247,8 @@ void EulerGrid::DiffuseWithNeumann(real_t dt) {
           // Clamp to avoid out of bounds access. Clamped values are initialized
           // to a wrong value but will be overwritten by the boundary condition
           // evaluation. All other values are correct.
-          real_t left{c1_[std::clamp(c-1, size_t{0}, num_boxes - 1)]};
-          real_t right{c1_[std::clamp(c+1, size_t{0}, num_boxes - 1)]};
+          real_t left{c1_[std::clamp(c - 1, size_t{0}, num_boxes - 1)]};
+          real_t right{c1_[std::clamp(c + 1, size_t{0}, num_boxes - 1)]};
           real_t bottom{c1_[std::clamp(b, size_t{0}, num_boxes - 1)]};
           real_t top{c1_[std::clamp(t, size_t{0}, num_boxes - 1)]};
           real_t north{c1_[std::clamp(n, size_t{0}, num_boxes - 1)]};
@@ -302,11 +302,9 @@ void EulerGrid::DiffuseWithNeumann(real_t dt) {
 }
 
 void EulerGrid::DiffuseWithPeriodic(real_t dt) {
-
   const size_t nx = resolution_;
   const size_t ny = resolution_;
   const size_t nz = resolution_;
-  const size_t num_boxes = nx * ny * nz;
 
   const real_t dx = box_length_;
   const real_t d = 1 - dc_[0];
@@ -320,17 +318,15 @@ void EulerGrid::DiffuseWithPeriodic(real_t dt) {
         ymax = ny;
       }
       for (size_t y = yy; y < ymax; y++) {
-        size_t x{0};
-        size_t c{0};
         size_t l{0};
         size_t r{0};
         size_t n{0};
         size_t s{0};
         size_t b{0};
         size_t t{0};
-        c = x + y * nx + z * nx * ny;
+        size_t c = y * nx + z * nx * ny;
 #pragma omp simd
-        for (x = 0; x < nx; x++) {
+        for (size_t x = 0; x < nx; x++) {
           l = c - 1;
           r = c + 1;
           n = c - nx;
@@ -338,56 +334,29 @@ void EulerGrid::DiffuseWithPeriodic(real_t dt) {
           b = c - nx * ny;
           t = c + nx * ny;
 
-           // Clamp to avoid out of bounds access. Clamped values are initialized
-          // to a wrong value but will be overwritten by the boundary condition
-          // evaluation. All other values are correct.
-          real_t left{c1_[std::clamp(l, size_t{0}, num_boxes - 1)]};
-          real_t right{c1_[std::clamp(r, size_t{0}, num_boxes - 1)]};
-          real_t bottom{c1_[std::clamp(b, size_t{0}, num_boxes - 1)]};
-          real_t top{c1_[std::clamp(t, size_t{0}, num_boxes - 1)]};
-          real_t north{c1_[std::clamp(n, size_t{0}, num_boxes - 1)]};
-          real_t south{c1_[std::clamp(s, size_t{0}, num_boxes - 1)]};
-
-          if (x == 0 || x == (nx - 1) || y == 0 || y == (ny - 1) || z == 0 ||
-              z == (nz - 1)) {
-
-            // For each box on the boundary, we find the concentration of the 
-            // box on the opposite side of the simulation:
-            //    |                          |
-            //    |u0  u1  u2 .... un-2  un-1|
-            //    |                          |
-            // The diffusion in u0 will be determined by the concentration in 
-            // u1 and un-1.
-
-
-            if (x == 0) {
-              l = nx-1 + y * nx + z * nx * ny;
-              left = c1_[l];
-            } else if (x == (nx - 1)) {
-              r = 0 + y * nx + z * nx * ny;
-              right = c1_[r];
-            }
-
-            if (y == 0) {
-              n = x + (ny-1) * nx + z * nx * ny;
-              north = c1_[n];
-            } else if (y == (ny - 1)) {
-              s = x + 0 * nx + z * nx * ny;
-              south = c1_[s];
-            }
-
-            if (z == 0) {
-              b = x + y * nx + (nz-1) * nx * ny;
-              bottom = c1_[b];
-            } else if (z == (nz - 1)) {
-              t = x + y * nx + 0 * nx * ny;
-              top = c1_[t];
-            }
+          // Adapt neighbor indices for boundary boxes for periodic boundary
+          if (x == 0) {
+            l = nx - 1 + y * nx + z * nx * ny;
+          } else if (x == (nx - 1)) {
+            r = 0 + y * nx + z * nx * ny;
           }
 
-          c2_[c] = c1_[c] * (1 - (mu_ * dt))
-                            + ( (d * dt / (dx*dx) ) * (left + right + north + south
-                                                       + top + bottom - 6.0*c1_[c]) );
+          if (y == 0) {
+            n = x + (ny - 1) * nx + z * nx * ny;
+          } else if (y == (ny - 1)) {
+            s = x + 0 * nx + z * nx * ny;
+          }
+
+          if (z == 0) {
+            b = x + y * nx + (nz - 1) * nx * ny;
+          } else if (z == (nz - 1)) {
+            t = x + y * nx + 0 * nx * ny;
+          }
+
+          // Stencil update
+          c2_[c] = c1_[c] * (1 - (mu_ * dt)) +
+                   ((d * dt / (dx * dx)) * (c1_[l] + c1_[r] + c1_[n] + c1_[s] +
+                                            c1_[t] + c1_[b] - 6.0 * c1_[c]));
 
           ++c;
         }

--- a/src/core/diffusion/euler_grid.cc
+++ b/src/core/diffusion/euler_grid.cc
@@ -353,12 +353,12 @@ void EulerGrid::DiffuseWithPeriodic(real_t dt) {
           // Clamp to avoid out of bounds access. Clamped values are initialized
           // to a wrong value but will be overwritten by the boundary condition
           // evaluation. All other values are correct.
-          real_t left{c1_[Clamp(l, 0, num_boxes - 1)]};
-          real_t right{c1_[Clamp(r, 0, num_boxes - 1)]};
-          real_t bottom{c1_[Clamp(b, 0, num_boxes - 1)]};
-          real_t top{c1_[Clamp(t, 0, num_boxes - 1)]};
-          real_t north{c1_[Clamp(n, 0, num_boxes - 1)]};
-          real_t south{c1_[Clamp(s, 0, num_boxes - 1)]};
+          real_t left{c1_[std::clamp(l, 0, num_boxes - 1)]};
+          real_t right{c1_[std::clamp(r, 0, num_boxes - 1)]};
+          real_t bottom{c1_[std::clamp(b, 0, num_boxes - 1)]};
+          real_t top{c1_[std::clamp(t, 0, num_boxes - 1)]};
+          real_t north{c1_[std::clamp(n, 0, num_boxes - 1)]};
+          real_t south{c1_[std::clamp(s, 0, num_boxes - 1)]};
 
           if (x == 0 || x == (nx - 1) || y == 0 || y == (ny - 1) || z == 0 ||
               z == (nz - 1)) {

--- a/src/core/diffusion/euler_grid.cc
+++ b/src/core/diffusion/euler_grid.cc
@@ -244,12 +244,15 @@ void EulerGrid::DiffuseWithNeumann(real_t dt) {
           b = c - nx * ny;
           t = c + nx * ny;
 
-          real_t left = c1_[c - 1];
-          real_t right = c1_[c + 1];
-          real_t bottom = c1_[b];
-          real_t top = c1_[t];
-          real_t north = c1_[n];
-          real_t south = c1_[s];
+          // Clamp to avoid out of bounds access. Clamped values are initialized
+          // to a wrong value but will be overwritten by the boundary condition
+          // evaluation. All other values are correct.
+          real_t left{c1_[std::clamp(l, size_t{0}, num_boxes - 1)]};
+          real_t right{c1_[std::clamp(r, size_t{0}, num_boxes - 1)]};
+          real_t bottom{c1_[std::clamp(b, size_t{0}, num_boxes - 1)]};
+          real_t top{c1_[std::clamp(t, size_t{0}, num_boxes - 1)]};
+          real_t north{c1_[std::clamp(n, size_t{0}, num_boxes - 1)]};
+          real_t south{c1_[std::clamp(s, size_t{0}, num_boxes - 1)]};
           real_t center_factor{6.0};
 
           if (x == 0 || x == (nx - 1) || y == 0 || y == (ny - 1) || z == 0 ||
@@ -335,12 +338,15 @@ void EulerGrid::DiffuseWithPeriodic(real_t dt) {
           b = c - nx * ny;
           t = c + nx * ny;
 
-          real_t left = c1_[l];
-          real_t right = c1_[r];
-          real_t bottom = c1_[b];
-          real_t top = c1_[t];
-          real_t north = c1_[n];
-          real_t south = c1_[s];
+           // Clamp to avoid out of bounds access. Clamped values are initialized
+          // to a wrong value but will be overwritten by the boundary condition
+          // evaluation. All other values are correct.
+          real_t left{c1_[std::clamp(l, size_t{0}, num_boxes - 1)]};
+          real_t right{c1_[std::clamp(r, size_t{0}, num_boxes - 1)]};
+          real_t bottom{c1_[std::clamp(b, size_t{0}, num_boxes - 1)]};
+          real_t top{c1_[std::clamp(t, size_t{0}, num_boxes - 1)]};
+          real_t north{c1_[std::clamp(n, size_t{0}, num_boxes - 1)]};
+          real_t south{c1_[std::clamp(s, size_t{0}, num_boxes - 1)]};
 
           if (x == 0 || x == (nx - 1) || y == 0 || y == (ny - 1) || z == 0 ||
               z == (nz - 1)) {

--- a/src/core/diffusion/euler_grid.cc
+++ b/src/core/diffusion/euler_grid.cc
@@ -244,6 +244,14 @@ void EulerGrid::DiffuseWithNeumann(real_t dt) {
           b = c - nx * ny;
           t = c + nx * ny;
 
+          real_t left = c1_[c - 1];
+          real_t right = c1_[c + 1];
+          real_t bottom = c1_[b];
+          real_t top = c1_[t];
+          real_t north = c1_[n];
+          real_t south = c1_[s];
+          real_t center_factor{6.0};
+
           if (x == 0 || x == (nx - 1) || y == 0 || y == (ny - 1) || z == 0 ||
               z == (nz - 1)) {
             real_t real_x = grid_dimensions_[0] + x * box_length_;
@@ -326,6 +334,13 @@ void EulerGrid::DiffuseWithPeriodic(real_t dt) {
           s = c + nx;
           b = c - nx * ny;
           t = c + nx * ny;
+
+          real_t left = c1_[l];
+          real_t right = c1_[r];
+          real_t bottom = c1_[b];
+          real_t top = c1_[t];
+          real_t north = c1_[n];
+          real_t south = c1_[s];
 
           if (x == 0 || x == (nx - 1) || y == 0 || y == (ny - 1) || z == 0 ||
               z == (nz - 1)) {

--- a/src/core/diffusion/euler_grid.cc
+++ b/src/core/diffusion/euler_grid.cc
@@ -244,17 +244,6 @@ void EulerGrid::DiffuseWithNeumann(real_t dt) {
           b = c - nx * ny;
           t = c + nx * ny;
 
-          // Clamp to avoid out of bounds access. Clamped values are initialized
-          // to a wrong value but will be overwritten by the boundary condition
-          // evaluation. All other values are correct.
-          real_t left{c1_[std::clamp(c - 1, size_t{0}, num_boxes - 1)]};
-          real_t right{c1_[std::clamp(c + 1, size_t{0}, num_boxes - 1)]};
-          real_t bottom{c1_[std::clamp(b, size_t{0}, num_boxes - 1)]};
-          real_t top{c1_[std::clamp(t, size_t{0}, num_boxes - 1)]};
-          real_t north{c1_[std::clamp(n, size_t{0}, num_boxes - 1)]};
-          real_t south{c1_[std::clamp(s, size_t{0}, num_boxes - 1)]};
-          real_t center_factor{6.0};
-
           if (x == 0 || x == (nx - 1) || y == 0 || y == (ny - 1) || z == 0 ||
               z == (nz - 1)) {
             real_t real_x = grid_dimensions_[0] + x * box_length_;
@@ -337,16 +326,6 @@ void EulerGrid::DiffuseWithPeriodic(real_t dt) {
           s = c + nx;
           b = c - nx * ny;
           t = c + nx * ny;
-
-          // Clamp to avoid out of bounds access. Clamped values are initialized
-          // to a wrong value but will be overwritten by the boundary condition
-          // evaluation. All other values are correct.
-          real_t left{c1_[std::clamp(l, size_t{0}, num_boxes - 1)]};
-          real_t right{c1_[std::clamp(r, size_t{0}, num_boxes - 1)]};
-          real_t bottom{c1_[std::clamp(b, size_t{0}, num_boxes - 1)]};
-          real_t top{c1_[std::clamp(t, size_t{0}, num_boxes - 1)]};
-          real_t north{c1_[std::clamp(n, size_t{0}, num_boxes - 1)]};
-          real_t south{c1_[std::clamp(s, size_t{0}, num_boxes - 1)]};
 
           if (x == 0 || x == (nx - 1) || y == 0 || y == (ny - 1) || z == 0 ||
               z == (nz - 1)) {

--- a/src/core/diffusion/euler_grid.h
+++ b/src/core/diffusion/euler_grid.h
@@ -52,6 +52,7 @@ class EulerGrid : public DiffusionGrid {
   void DiffuseWithOpenEdge(real_t dt) override;
   void DiffuseWithDirichlet(real_t dt) override;
   void DiffuseWithNeumann(real_t dt) override;
+  void DiffuseWithPeriodic(real_t dt) override;
 
  private:
   BDM_CLASS_DEF_OVERRIDE(EulerGrid, 1);

--- a/src/core/param/param.h
+++ b/src/core/param/param.h
@@ -236,7 +236,7 @@ struct Param {
   real_t max_bound = 100;
 
   /// Define the boundary condition of the diffusion grid [open, closed,
-  /// Neumann, Dirichlet]\n
+  /// Neumann, Dirichlet, Periodic]\n
   /// Default value: `"Neumann"`\n TOML config file:
   ///
   ///     [simulation]

--- a/test/unit/core/diffusion_init_test.h
+++ b/test/unit/core/diffusion_init_test.h
@@ -31,6 +31,7 @@ class TestGrid : public DiffusionGrid {
   void DiffuseWithOpenEdge(real_t dt) override { return; };
   void DiffuseWithDirichlet(real_t dt) override { return; };
   void DiffuseWithNeumann(real_t dt) override { return; };
+  void DiffuseWithPeriodic(real_t dt) override { return; };
 
   void Swap() { c1_.swap(c2_); }
 

--- a/test/unit/core/diffusion_test.cc
+++ b/test/unit/core/diffusion_test.cc
@@ -1135,10 +1135,10 @@ TEST(DiffusionTest, EulerNeumannNonZeroBoundaries) {
 TEST(DiffusionTest, EulerPeriodicBoundaries) {
   double simulation_time_step{0.1};
   auto set_param = [&](Param* param) {
-          param->bound_space = Param::BoundSpaceMode::kClosed;
-          param->min_bound = -50;
-          param->max_bound = 50;
-          param->diffusion_boundary_condition = "Periodic";
+    param->bound_space = Param::BoundSpaceMode::kClosed;
+    param->min_bound = -50;
+    param->max_bound = 50;
+    param->diffusion_boundary_condition = "Periodic";
   };
   Simulation simulation(TEST_NAME, set_param);
 


### PR DESCRIPTION
This is the pull request for adding periodic boundaries to the diffusion grid. This is simply an extra function on top of Neumann, Dirichlet, open and closed boundaries that the user can choose from. This also includes a unit test to confirm the boundary conditions work. 

Periodic boundaries allows a diffusive substance to move from one boundary to another. This feature is the same as the taurus boundaries for agents, except it is for diffusion. An illustration can be seen below:

    |                                                               |
    | u0    u1    u2    ............     uN-2    uN-1 |
    |                                                               |

When calculating diffusion in u0, it will look at the concentration in u1 and uN-1 to determine the change. If the concentration in uN-1 is lower/higher than u0 then concentration will be transferred from/to u0. Likewise when calculating diffusion in uN-1, it will look at uN-2 and u0, and determine the change in the same way. This transfer through the boundary does not modify the total concentration in the system: it only affects how the concentration can move through the simulation space. Many biological systems simulated with BioDynaMo represent small slices of the much larger system. Periodic boundaries promotes the idea of concentration coming from "other parts" of the biological system. There is a subtle but important difference between a diffusive substance colliding with a large concentration of substances vs colliding with a solid wall.

@TobiasDuswald and @nicogno since you two implemented the Neumann and Dirichlet boundaries, I figured you would be the right people to review this update. Feel free to take a look at this request and potentially do any stress testing when you have time. 