### PR TITLE
Add -X parameter to sonar-scanner for full debug log

### DIFF
--- a/.github/workflows/sonar-source.yml
+++ b/.github/workflows/sonar-source.yml
@@ -83,4 +83,4 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: |
           source $(find /home -path "*/bin/*" -name "*thisbdm.sh")
-          sonar-scanner --define sonar.cfamily.build-wrapper-output="${{ env.BUILD_WRAPPER_OUT_DIR }}"
+          sonar-scanner -X --define sonar.cfamily.build-wrapper-output="${{ env.BUILD_WRAPPER_OUT_DIR }}"


### PR DESCRIPTION
Maybe it's useful in order to debug if the workflow fails, also works with --verbose