### PR TITLE
Remove editor whitespace changes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,7 +6,7 @@ root = true
 charset = utf-8
 end_of_line = lf
 insert_final_newline = true
-trim_trailing_whitespace = true
+trim_trailing_whitespace = false
 indent_style = space
 indent_size = 2
 


### PR DESCRIPTION
Remove the trim trailing white spaces option to achieve a cleaner file changes view.