### PR TITLE
Change FetchContent_Populate to FetchContent_MakeAvailable

### DIFF
--- a/cmake/utils.cmake
+++ b/cmake/utils.cmake
@@ -549,12 +549,9 @@ Unset the environment variable BDM_LOCAL_LFS to download the file.")
 	DOWNLOAD_DIR ${DEST_PARENT}
 	SOURCE_DIR ${DEST}
     )
-    
-    FetchContent_GetProperties(${TAR_FILENAME})
-    if (NOT ${TAR_FILENAME}_POPULATED)
-        FetchContent_Populate(${TAR_FILENAME})
-    endif()
-    
+
+    FetchContent_MakeAvailable(${TAR_FILENAME})
+
     # Remove subbuild files, we don't need them
     file(REMOVE_RECURSE ${CMAKE_BINARY_DIR}/_deps/)
   endif()


### PR DESCRIPTION
According to #386, since FetchContent_Populate is deprecated we need to get rid of it. This PR makes this possible replacing it with the function `FetchContent_MakeAvailable`