### PR TITLE
Make headers self-contained

### DIFF
--- a/src/core/operation/mechanical_forces_op.h
+++ b/src/core/operation/mechanical_forces_op.h
@@ -31,7 +31,6 @@
 #include "core/simulation.h"
 #include "core/util/math.h"
 #include "core/util/thread_info.h"
-#include "core/operation/operation_registry.h"
 
 namespace bdm {
 

--- a/src/core/operation/mechanical_forces_op.h
+++ b/src/core/operation/mechanical_forces_op.h
@@ -31,6 +31,7 @@
 #include "core/simulation.h"
 #include "core/util/math.h"
 #include "core/util/thread_info.h"
+#include "core/operation/operation_registry.h"
 
 namespace bdm {
 

--- a/src/neuroscience/new_agent_event/neurite_branching_event.h
+++ b/src/neuroscience/new_agent_event/neurite_branching_event.h
@@ -17,8 +17,8 @@
 
 #include <array>
 #include "core/agent/new_agent_event.h"
-#include "core/real_t.h"
 #include "core/container/math_array.h"
+#include "core/real_t.h"
 
 namespace bdm {
 namespace neuroscience {

--- a/src/neuroscience/new_agent_event/neurite_branching_event.h
+++ b/src/neuroscience/new_agent_event/neurite_branching_event.h
@@ -17,6 +17,8 @@
 
 #include <array>
 #include "core/agent/new_agent_event.h"
+#include "core/real_t.h"
+#include "core/container/math_array.h"
 
 namespace bdm {
 namespace neuroscience {

--- a/src/neuroscience/new_agent_event/new_neurite_extension_event.h
+++ b/src/neuroscience/new_agent_event/new_neurite_extension_event.h
@@ -16,6 +16,7 @@
 #define NEUROSCIENCE_NEW_AGENT_EVENT_NEW_NEURITE_EXTENSION_EVENT_H_
 
 #include "core/agent/new_agent_event.h"
+#include "core/real_t.h"
 
 namespace bdm {
 namespace neuroscience {

--- a/src/neuroscience/new_agent_event/side_neurite_extension_event.h
+++ b/src/neuroscience/new_agent_event/side_neurite_extension_event.h
@@ -16,8 +16,8 @@
 #define NEUROSCIENCE_NEW_AGENT_EVENT_SIDE_NEURITE_EXTENSION_EVENT_H_
 
 #include "core/agent/new_agent_event.h"
-#include "core/real_t.h"
 #include "core/container/math_array.h"
+#include "core/real_t.h"
 
 namespace bdm {
 namespace neuroscience {

--- a/src/neuroscience/new_agent_event/side_neurite_extension_event.h
+++ b/src/neuroscience/new_agent_event/side_neurite_extension_event.h
@@ -16,6 +16,8 @@
 #define NEUROSCIENCE_NEW_AGENT_EVENT_SIDE_NEURITE_EXTENSION_EVENT_H_
 
 #include "core/agent/new_agent_event.h"
+#include "core/real_t.h"
+#include "core/container/math_array.h"
 
 namespace bdm {
 namespace neuroscience {

--- a/src/neuroscience/new_agent_event/split_neurite_element_event.h
+++ b/src/neuroscience/new_agent_event/split_neurite_element_event.h
@@ -16,6 +16,7 @@
 #define NEUROSCIENCE_NEW_AGENT_EVENT_SPLIT_NEURITE_ELEMENT_EVENT_H_
 
 #include "core/agent/new_agent_event.h"
+#include "core/real_t.h"
 
 namespace bdm {
 namespace neuroscience {

--- a/test/unit/core/operation/dividing_cell_op_test.h
+++ b/test/unit/core/operation/dividing_cell_op_test.h
@@ -21,9 +21,9 @@
 
 #include "core/agent/cell.h"
 #include "core/operation/dividing_cell_op.h"
+#include "core/operation/operation_registry.h"
 #include "core/resource_manager.h"
 #include "unit/test_util/test_util.h"
-#include "core/operation/operation_registry.h"
 
 namespace bdm {
 namespace dividing_cell_op_test_internal {

--- a/test/unit/core/operation/dividing_cell_op_test.h
+++ b/test/unit/core/operation/dividing_cell_op_test.h
@@ -23,6 +23,7 @@
 #include "core/operation/dividing_cell_op.h"
 #include "core/resource_manager.h"
 #include "unit/test_util/test_util.h"
+#include "core/operation/operation_registry.h"
 
 namespace bdm {
 namespace dividing_cell_op_test_internal {

--- a/test/unit/core/operation/mechanical_forces_op_test.h
+++ b/test/unit/core/operation/mechanical_forces_op_test.h
@@ -17,8 +17,8 @@
 
 #include "core/agent/cell.h"
 #include "core/operation/mechanical_forces_op.h"
-#include "unit/test_util/test_util.h"
 #include "core/operation/operation_registry.h"
+#include "unit/test_util/test_util.h"
 
 namespace bdm {
 namespace mechanical_forces_op_test_internal {

--- a/test/unit/core/operation/mechanical_forces_op_test.h
+++ b/test/unit/core/operation/mechanical_forces_op_test.h
@@ -18,6 +18,7 @@
 #include "core/agent/cell.h"
 #include "core/operation/mechanical_forces_op.h"
 #include "unit/test_util/test_util.h"
+#include "core/operation/operation_registry.h"
 
 namespace bdm {
 namespace mechanical_forces_op_test_internal {


### PR DESCRIPTION
According to [ROOT C++ Modules documentation](https://github.com/root-project/root/blob/master/README/README.CXXMODULES.md#changes-required-by-the-users), every header file should be able to compile on its own. This PR fixes that by including some missing headers.