### PR TITLE
Add missing includes to new_neurite_extension_event.h

### DIFF
--- a/src/neuroscience/new_agent_event/new_neurite_extension_event.h
+++ b/src/neuroscience/new_agent_event/new_neurite_extension_event.h
@@ -16,6 +16,7 @@
 #define NEUROSCIENCE_NEW_AGENT_EVENT_NEW_NEURITE_EXTENSION_EVENT_H_
 
 #include "core/agent/new_agent_event.h"
+#include "core/real_t.h"
 
 namespace bdm {
 namespace neuroscience {


### PR DESCRIPTION
We use real_t in this header, so we also should include the header that contain this type.