### PR TITLE
Add missing includes to neurite_branching_event.h

### DIFF
--- a/src/neuroscience/new_agent_event/neurite_branching_event.h
+++ b/src/neuroscience/new_agent_event/neurite_branching_event.h
@@ -17,6 +17,8 @@
 
 #include <array>
 #include "core/agent/new_agent_event.h"
+#include "core/container/math_array.h"
+#include "core/real_t.h"
 
 namespace bdm {
 namespace neuroscience {


### PR DESCRIPTION
We use real_t and Real3 in this header, so we also should include the headers that contains these classes.