### PR TITLE
Add missing real_t header to split_neurite_element_event.h

### DIFF
--- a/src/neuroscience/new_agent_event/split_neurite_element_event.h
+++ b/src/neuroscience/new_agent_event/split_neurite_element_event.h
@@ -16,6 +16,7 @@
 #define NEUROSCIENCE_NEW_AGENT_EVENT_SPLIT_NEURITE_ELEMENT_EVENT_H_
 
 #include "core/agent/new_agent_event.h"
+#include "core/real_t.h"
 
 namespace bdm {
 namespace neuroscience {


### PR DESCRIPTION
We use real_t in this header, so we should include the real_t.h header