### PR TITLE
Add missing includes to side_neurite_extension_event.h

### DIFF
--- a/src/neuroscience/new_agent_event/side_neurite_extension_event.h
+++ b/src/neuroscience/new_agent_event/side_neurite_extension_event.h
@@ -16,6 +16,8 @@
 #define NEUROSCIENCE_NEW_AGENT_EVENT_SIDE_NEURITE_EXTENSION_EVENT_H_
 
 #include "core/agent/new_agent_event.h"
+#include "core/container/math_array.h"
+#include "core/real_t.h"
 
 namespace bdm {
 namespace neuroscience {


### PR DESCRIPTION
We use real_t and Real3 in this header, so we also should include the headers that contains these classes.