### PR TITLE
Add missing header to dividing_cell_op_test.h

### DIFF
--- a/test/unit/core/operation/dividing_cell_op_test.h
+++ b/test/unit/core/operation/dividing_cell_op_test.h
@@ -21,6 +21,7 @@
 
 #include "core/agent/cell.h"
 #include "core/operation/dividing_cell_op.h"
+#include "core/operation/operation_registry.h"
 #include "core/resource_manager.h"
 #include "unit/test_util/test_util.h"
 


### PR DESCRIPTION
We use NewOperation() in this file, so we should add the header where the function is defined.