### PR TITLE
Add missing header to mechanical_forces_op_test.h

### DIFF
--- a/test/unit/core/operation/mechanical_forces_op_test.h
+++ b/test/unit/core/operation/mechanical_forces_op_test.h
@@ -17,6 +17,7 @@
 
 #include "core/agent/cell.h"
 #include "core/operation/mechanical_forces_op.h"
+#include "core/operation/operation_registry.h"
 #include "unit/test_util/test_util.h"
 
 namespace bdm {


### PR DESCRIPTION
We use NewOperation() in this file, so we should add the header where the function is definded.