### PR TITLE
Fix compiler warning

### DIFF
--- a/demo/analytic_continuum/src/continuum_model.h
+++ b/demo/analytic_continuum/src/continuum_model.h
@@ -23,7 +23,7 @@ namespace bdm {
 /// We define a custom analytic continuum model. We inherit form BioDynaMo's
 /// base class `ScalarField` to obey the API. We implement the function:
 /// f(x,y,z,t) = (1-e^{-t}) sin(w_x*x) * sin(w_y*y)
-class AnalyticContinuum : public ScalarField {
+class AnalyticContinuum final : public ScalarField {
  public:
   AnalyticContinuum() = default;
   explicit AnalyticContinuum(const TRootIOCtor *) {}


### PR DESCRIPTION
We add the `final` specifier to the `AnalyticContinuum` class to silence the following warning:
```
[...]/continuum_model.h:30:24: warning: class with destructor marked 'final' cannot be inherited from [-Wfinal-dtor-non-final-class]
  ~AnalyticContinuum() final = default;
                       ^
[...]/continuum_model.h:26:7: note: mark 'bdm::AnalyticContinuum' as 'final' to silence this warning
class AnalyticContinuum : public ScalarField {
```