### PR TITLE
Remove ubuntu-20.04 from GitHub Actions workflows

### DIFF
--- a/.github/workflows/repository-checks.yml
+++ b/.github/workflows/repository-checks.yml
@@ -9,7 +9,7 @@ concurrency:
 
 jobs:
   code-style:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
 

--- a/.github/workflows/sonar-source.yml
+++ b/.github/workflows/sonar-source.yml
@@ -13,7 +13,7 @@ concurrency:
 jobs:
   build:
     name: Sonar Source Analysis
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       SONAR_SERVER_URL: "https://sonarcloud.io"
       BUILD_WRAPPER_OUT_DIR: build_wrapper_output_directory # Directory where build-wrapper output will be placed

--- a/.github/workflows/ubuntu-ci.yml
+++ b/.github/workflows/ubuntu-ci.yml
@@ -14,7 +14,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-20.04, ubuntu-22.04]
+        os: [ubuntu-22.04]
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/.github/workflows/ubuntu-system-ci.yml
+++ b/.github/workflows/ubuntu-system-ci.yml
@@ -21,7 +21,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-20.04, ubuntu-22.04]
+        os: [ubuntu-22.04]
     runs-on: ${{ matrix.os }}
 
     steps:


### PR DESCRIPTION
This PR removes references to `ubuntu-20.04` from the GitHub Actions workflows as the runner will be deprecated on April 15, 2025. The workflows now use only `ubuntu-22.04`.