### PR TITLE
Add compiler flags to macOS CI 

### DIFF
--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -52,6 +52,7 @@ jobs:
           -Dbenchmark=ON \
           -Dlibgit2=ON \
           -DCMAKE_BUILD_TYPE=Release \
+          -DCMAKE_CXX_FLAGS="-Wall -Wextra -Wpedantic -Werror -fsanitize=address -fsanitize=undefined -Wno-error=unused-parameter" \
           -B build
         cmake --build build --parallel --config Release
 


### PR DESCRIPTION
This PR updates the macOS CI to use -Wall -Wextra -Wpedantic -Werror and enables AddressSanitizer and UndefinedBehaviorSanitizer to catch warnings and runtime errors early.

Fixes #351 
