### PR TITLE
Fix CMake Version Compatibility

### DIFF
--- a/Singularity
+++ b/Singularity
@@ -53,7 +53,7 @@ From:ubuntu:20.04
   python3 -m pip install --upgrade pip
   python3 -m pip install numpy
 
-  pip install cmake --upgrade
+  # pip install cmake --upgrade
   pyenv global 3.9.1
   
   git config --system user.name "Test User"
@@ -66,6 +66,13 @@ From:ubuntu:20.04
 
   mkdir build
   cd build
+
+  echo "==> Installing CMake 3.27.9 to /usr/local"
+  CMAKE_VER=3.27.9
+  CMAKE_SH="cmake-${CMAKE_VER}-linux-x86_64.sh"
+  wget -q https://github.com/Kitware/CMake/releases/download/v${CMAKE_VER}/${CMAKE_SH}
+  sudo bash "${CMAKE_SH}" --prefix=/usr/local --skip-license
+  rm "${CMAKE_SH}"
 
   cmake -G Ninja -DCMAKE_BUILD_TYPE=Release ..
   

--- a/util/installation/ubuntu-22.04/prerequisites.sh
+++ b/util/installation/ubuntu-22.04/prerequisites.sh
@@ -45,6 +45,16 @@ sudo apt install -y cmake-data=3.22.1-1ubuntu1.22.04.1
 sudo apt-get install -y \
   $(cat $BDM_PROJECT_DIR/util/installation/ubuntu-22.04/package_list_required)
 
+
+echo "==> Installing CMake 3.27.9 to /usr/local"
+CMAKE_VER=3.27.9
+CMAKE_SH="cmake-${CMAKE_VER}-linux-x86_64.sh"
+wget -q https://github.com/Kitware/CMake/releases/download/v${CMAKE_VER}/${CMAKE_SH}
+sudo bash "${CMAKE_SH}" --prefix=/usr/local --skip-license
+rm "${CMAKE_SH}"
+
+
+
 if [ -n "${PYENV_ROOT}" ]; then
   unset PYENV_ROOT
 fi


### PR DESCRIPTION
This pull request pins CMake to version 3.27.9 to avoid issues with newer versions (CMake 4.x) during the ParaView build process.

