### PR TITLE
Update Singularity to install CMake 3.19.3 for compatibility

### DIFF
--- a/Singularity
+++ b/Singularity
@@ -25,6 +25,13 @@ From:ubuntu:20.04
     libbz2-dev libnuma-dev libomp5 libomp-dev libopenmpi-dev libpthread-stubs0-dev zlib1g-dev libbz2-dev libffi-dev liblzma-dev libreadline-dev libsqlite3-dev libssl-dev python-openssl tk-dev \
     xz-utils zlib1g-dev sudo libblas-dev liblapack-dev nano locales locales-all ninja-build python3-pip freeglut3-dev valgrind xvfb
   
+  CMAKE_VER=3.19.3
+  CMAKE_SH="cmake-${CMAKE_VER}-linux-x86_64.sh"
+  curl -L -O  https://github.com/Kitware/CMake/releases/download/v${CMAKE_VER}/${CMAKE_SH}
+  bash "${CMAKE_SH}" --prefix=/usr/local --skip-license
+  rm "${CMAKE_SH}"
+
+
   dpkg-reconfigure locales
   locale-gen
   
@@ -53,7 +60,7 @@ From:ubuntu:20.04
   python3 -m pip install --upgrade pip
   python3 -m pip install numpy
 
-  pip install cmake --upgrade
+  # pip install cmake --upgrade
   pyenv global 3.9.1
   
   git config --system user.name "Test User"


### PR DESCRIPTION
This pull request pins CMake to version 3.19.3 on Singularity file to avoid issues with newer versions (CMake 4.x). 