### PR TITLE
Update Style Guide Checks to Run on Ubuntu 22.04 Instead of 20.04

### DIFF
--- a/.github/workflows/ubuntu-ci.yml
+++ b/.github/workflows/ubuntu-ci.yml
@@ -125,4 +125,4 @@ jobs:
         cmake --build . --target show-format || true
         cmake --build . --target show-tidy || true
         cmake --build . --target check-cpplint || true
-      if: github.event_name == 'pull_request' && matrix.os == 'ubuntu-20.04'
+      if: github.event_name == 'pull_request' && matrix.os == 'ubuntu-22.04'


### PR DESCRIPTION
This pull request updates the workflow condition in .github/workflows/ubuntu-ci.yml so that the style guide checks are executed when matrix.os is ubuntu-22.04, instead of ubuntu-20.04.