### PR TITLE
macOS CI: unpin CMake on GHA runners to fix Homebrew conflict

### DIFF
--- a/.github/workflows/macos-system-ci.yml
+++ b/.github/workflows/macos-system-ci.yml
@@ -44,6 +44,9 @@ jobs:
       shell: zsh {0}
       run: |
         brew install curl
+        # GHA macOS: unpin CMake to fix Homebrew conflict (actions/runner-images#12912)
+        brew uninstall --force cmake || true
+        brew untap local/pinned || true
         curl https://raw.githubusercontent.com/${GHA_REPOSITORY}/${GHA_BRANCH_NAME}/util/install | bash
         # remove whole bidynamo repository to catch errors related to paths pointing into the build dir
         mktemp -d


### PR DESCRIPTION
Remove pinned CMake (local/pinned) on GitHub Actions macOS to avoid Homebrew conflicts. We uninstall CMake and untap local/pinned before running the installer.

Reference
https://github.com/actions/runner-images/issues/12912