### PR TITLE
Add missing C++ standard library includes

### DIFF
--- a/src/core/multi_simulation/optimization_param_type/log_range_param.h
+++ b/src/core/multi_simulation/optimization_param_type/log_range_param.h
@@ -15,6 +15,7 @@
 #ifndef CORE_MULTI_SIMULATION_OPTIMIZATION_PARAM_TYPE_LOG_RANGE_PARAM_H_
 #define CORE_MULTI_SIMULATION_OPTIMIZATION_PARAM_TYPE_LOG_RANGE_PARAM_H_
 
+#include <cmath>
 #include <string>
 
 #include "core/multi_simulation/optimization_param_type/optimization_param_type.h"

--- a/src/core/multi_simulation/optimization_param_type/range_param.h
+++ b/src/core/multi_simulation/optimization_param_type/range_param.h
@@ -15,6 +15,7 @@
 #ifndef CORE_MULTI_SIMULATION_OPTIMIZATION_PARAM_TYPE_RANGE_PARAM_H_
 #define CORE_MULTI_SIMULATION_OPTIMIZATION_PARAM_TYPE_RANGE_PARAM_H_
 
+#include <cmath>
 #include <string>
 
 #include "core/multi_simulation/optimization_param_type/optimization_param_type.h"

--- a/third_party/cpptoml/cpptoml.h
+++ b/third_party/cpptoml/cpptoml.h
@@ -13,6 +13,7 @@
 #include <cstring>
 #include <fstream>
 #include <iomanip>
+#include <limits>
 #include <map>
 #include <memory>
 #include <sstream>


### PR DESCRIPTION
cpptoml.h, log_range_param.h, and range_param.h rely on <limits> and <cmath> being transitively included through other headers. Adding explicit includes ensures correct builds regardless of which headers are pulled in by dependencies.

Note: the cpptoml.h change here overlaps with https://github.com/BioDynaMo/biodynamo/pull/440, which removes cpptoml for toml++.