### PR TITLE
Add missing C++ standard library includes

### DIFF
--- a/src/core/multi_simulation/optimization_param_type/log_range_param.h
+++ b/src/core/multi_simulation/optimization_param_type/log_range_param.h
@@ -15,6 +15,7 @@
 #ifndef CORE_MULTI_SIMULATION_OPTIMIZATION_PARAM_TYPE_LOG_RANGE_PARAM_H_
 #define CORE_MULTI_SIMULATION_OPTIMIZATION_PARAM_TYPE_LOG_RANGE_PARAM_H_
 
+#include <cmath>
 #include <string>
 
 #include "core/multi_simulation/optimization_param_type/optimization_param_type.h"

--- a/src/core/multi_simulation/optimization_param_type/range_param.h
+++ b/src/core/multi_simulation/optimization_param_type/range_param.h
@@ -15,6 +15,7 @@
 #ifndef CORE_MULTI_SIMULATION_OPTIMIZATION_PARAM_TYPE_RANGE_PARAM_H_
 #define CORE_MULTI_SIMULATION_OPTIMIZATION_PARAM_TYPE_RANGE_PARAM_H_
 
+#include <cmath>
 #include <string>
 
 #include "core/multi_simulation/optimization_param_type/optimization_param_type.h"


### PR DESCRIPTION
## Summary
- `log_range_param.h` and `range_param.h` use symbols from `<cmath>` but rely on transitive includes
- Adds explicit `#include <cmath>` to ensure correct builds regardless of header inclusion order

## Test plan
- [ ] Verify project builds successfully on CI