### PR TITLE
Replace NULL with nullptr in C++ sources

### DIFF
--- a/benchmark/main.cc
+++ b/benchmark/main.cc
@@ -9,5 +9,5 @@ int main(int argc, char** argv) {
   ::benchmark::Initialize(&argc, argv);
   if (::benchmark::ReportUnrecognizedArguments(argc, argv))
     return 1;
-  ::benchmark::RunSpecifiedBenchmarks(NULL, rep);
+  ::benchmark::RunSpecifiedBenchmarks(nullptr, rep);
 }

--- a/src/core/param/command_line_options.cc
+++ b/src/core/param/command_line_options.cc
@@ -60,7 +60,7 @@ void CommandLineOptions::Parse() {
     argv_copy[i] = (char*)malloc(length);
     memcpy(argv_copy[i], argv_[i], length);
   }
-  argv_copy[argc_] = NULL;
+  argv_copy[argc_] = nullptr;
 
   // Perform parsing (consumes argc_copy and argv_copy)
   if (parser_) {

--- a/src/core/visualization/paraview/mapped_data_array.h
+++ b/src/core/visualization/paraview/mapped_data_array.h
@@ -364,7 +364,7 @@ void MappedDataArray<TScalar, TClass, TDataMember>::Squeeze() {
 template <typename TScalar, typename TClass, typename TDataMember>
 vtkArrayIterator* MappedDataArray<TScalar, TClass, TDataMember>::NewIterator() {
   vtkErrorMacro(<< "Not implemented.");
-  return NULL;
+  return nullptr;
 }
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Replaces remaining uses of `NULL` with `nullptr` in C++ source files
- Follows modern C++ best practices

## Test plan
- [ ] Verify project builds successfully on CI