### PR TITLE
Replace deprecated sonarcloud-github-c-cpp action

### DIFF
--- a/.github/workflows/sonar-source.yml
+++ b/.github/workflows/sonar-source.yml
@@ -22,8 +22,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
-      - name: Install sonar-scanner and build-wrapper
-        uses: SonarSource/sonarcloud-github-c-cpp@v2
+      - name: Install Build Wrapper
+        uses: SonarSource/sonarqube-scan-action/install-build-wrapper@v7
       - name: Install dependencies
         run: |
           sudo apt-get update
@@ -78,9 +78,11 @@ jobs:
           echo "\n ... \n"
           tail -n 7 "$FILE"
       - name: Run sonar-scanner
+        uses: SonarSource/sonarqube-scan-action@v7
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: |
-          source $(find /home -path "*/bin/*" -name "*thisbdm.sh")
-          sonar-scanner -X --define sonar.cfamily.build-wrapper-output="${{ env.BUILD_WRAPPER_OUT_DIR }}"
+        with:
+          args: >
+            -X
+            --define sonar.cfamily.compile-commands=${{ env.BUILD_WRAPPER_OUT_DIR }}/compile_commands.json


### PR DESCRIPTION
## Summary
The `sonarcloud-github-c-cpp` action used in CI was [deprecated and removed](https://community.sonarsource.com/t/release-and-deprecation-of-github-action-for-c-c-and-objective-c-with-sonarqube-cloud/133185). Replaced with the current `sonarqube-scan-action` and updated the build wrapper download step to use the latest API.

## Test plan
- [ ] Verify SonarCloud workflow runs successfully on CI