### PR TITLE
ci: fix script download 404 on PRs from forks

### DIFF
--- a/.github/workflows/macos-system-ci.yml
+++ b/.github/workflows/macos-system-ci.yml
@@ -38,7 +38,7 @@ jobs:
           echo "GHA_BRANCH_NAME=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
         fi
 
-        echo "GHA_REPOSITORY=${{ github.repository}}" >> $GITHUB_ENV
+        echo "GHA_REPOSITORY=${{ github.event.pull_request.head.repo.full_name || github.repository }}" >> $GITHUB_ENV
 
     - name: Install BioDynaMo
       shell: zsh {0}

--- a/.github/workflows/ubuntu-system-ci.yml
+++ b/.github/workflows/ubuntu-system-ci.yml
@@ -34,7 +34,7 @@ jobs:
           echo "GHA_BRANCH_NAME=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
         fi
 
-        echo "GHA_REPOSITORY=${{ github.repository }}" >> $GITHUB_ENV
+        echo "GHA_REPOSITORY=${{ github.event.pull_request.head.repo.full_name || github.repository }}" >> $GITHUB_ENV
 
     - name: Set OSVERS
       run: |


### PR DESCRIPTION
Update GHA_REPOSITORY to use GitHub context variables. This ensures that scripts are fetched from the correct head repository and branch during Pull Request events, preventing fetching a wrong URL.

This closes #453