### PR TITLE
Fix DiffusionGrid::GetConcentration error label

### DIFF
--- a/src/core/diffusion/diffusion_grid.cc
+++ b/src/core/diffusion/diffusion_grid.cc
@@ -406,7 +406,7 @@ real_t DiffusionGrid::GetValue(const Real3& position) const {
 /// Get the concentration at specified voxel
 real_t DiffusionGrid::GetConcentration(const size_t idx) const {
   if (idx >= total_num_boxes_) {
-    Log::Error("DiffusionGrid::ChangeConcentrationBy",
+    Log::Error("DiffusionGrid::GetConcentration",
                "You tried to get the concentration outside the bounds of "
                "the diffusion grid!");
     return 0;


### PR DESCRIPTION
## Summary
- The out-of-bounds error in `GetConcentration` incorrectly identifies itself as `ChangeConcentrationBy`, making it impossible to distinguish read vs write OOB errors when debugging.

## Test plan
- [ ] Existing unit tests pass (no behavioral change, label only)