### PR TITLE
Cache env and param pointers in InPlaceExecutionContext

### DIFF
--- a/src/core/execution_context/in_place_exec_ctxt.cc
+++ b/src/core/execution_context/in_place_exec_ctxt.cc
@@ -140,15 +140,26 @@ void InPlaceExecutionContext::TearDownIterationAll(
 }
 
 void InPlaceExecutionContext::SetupAgentOpsAll(
-    const std::vector<ExecutionContext*>& all_exec_ctxts) {}
+    const std::vector<ExecutionContext*>& all_exec_ctxts) {
+  auto* sim = Simulation::GetActive();
+  auto* env = sim->GetEnvironment();
+  auto* param = sim->GetParam();
+  for (auto* ec : all_exec_ctxts) {
+    auto* ctxt = bdm_static_cast<InPlaceExecutionContext*>(ec);
+    ctxt->cached_env_ = env;
+    ctxt->cached_param_ = param;
+  }
+}
 
 void InPlaceExecutionContext::TearDownAgentOpsAll(
     const std::vector<ExecutionContext*>& all_exec_ctxts) {}
 
 void InPlaceExecutionContext::Execute(
     Agent* agent, AgentHandle ah, const std::vector<Operation*>& operations) {
-  auto* env = Simulation::GetActive()->GetEnvironment();
-  auto* param = Simulation::GetActive()->GetParam();
+  auto* env =
+      cached_env_ ? cached_env_ : Simulation::GetActive()->GetEnvironment();
+  auto* param =
+      cached_param_ ? cached_param_ : Simulation::GetActive()->GetParam();
 
   if (param->thread_safety_mechanism ==
       Param::ThreadSafetyMechanism::kUserSpecified) {

--- a/src/core/execution_context/in_place_exec_ctxt.h
+++ b/src/core/execution_context/in_place_exec_ctxt.h
@@ -34,6 +34,9 @@
 
 namespace bdm {
 
+class Environment;
+struct Param;
+
 namespace in_place_exec_ctxt_detail {
 class InPlaceExecutionContext_NeighborCacheValidity_Test;
 }
@@ -156,6 +159,11 @@ class InPlaceExecutionContext : public ExecutionContext {
   real_t cached_squared_search_radius_ = 0.0;
   /// Cache the value of Param::cache_neighbors
   bool cache_neighbors_ = false;
+
+  /// Cached pointers refreshed once per agent-ops phase in SetupAgentOpsAll,
+  /// so Execute avoids per-agent Simulation::GetActive() lookups.
+  Environment* cached_env_ = nullptr;
+  const Param* cached_param_ = nullptr;
 
   /// Check whether or not the neighbors in `neighbor_cache_` were queried with
   /// the same squared radius (`cached_squared_search_radius_`) as currently


### PR DESCRIPTION
## Summary
- Caches `Environment*` and `Param*` pointers once per agent-ops phase in `SetupAgentOpsAll`, eliminating two `Simulation::GetActive()` lookups per agent per iteration in `Execute`
- Falls back to `Simulation::GetActive()` when cached pointers are null (e.g. when `Execute` is called outside the agent-ops phase, as in `CopyExecutionContext`)

## Test plan
- [ ] Existing unit tests pass (`make check`)
- [ ] Verified with profiling that `Simulation::GetActive()` calls in `Execute` are eliminated during normal iteration