### PR TITLE
Skip UpdateStaticness when detect_static_agents is false

### DIFF
--- a/src/core/operation/default_ops.cc
+++ b/src/core/operation/default_ops.cc
@@ -48,7 +48,18 @@ BDM_REGISTER_OP(MechanicalForcesOpOpenCL, "mechanical forces", kOpenCl);
 struct UpdateStaticnessOp : public AgentOperationImpl {
   BDM_OP_HEADER(UpdateStaticnessOp);
 
-  void operator()(Agent* agent) override { agent->UpdateStaticness(); }
+  void SetUp() override {
+    detect_static_ = Simulation::GetActive()->GetParam()->detect_static_agents;
+  }
+
+  void operator()(Agent* agent) override {
+    if (!detect_static_) {
+      return;
+    }
+    agent->UpdateStaticness();
+  }
+
+  bool detect_static_ = false;
 };
 
 BDM_REGISTER_OP(UpdateStaticnessOp, "update staticness", kCpu);


### PR DESCRIPTION
## Summary
- Adds a `SetUp` override to `UpdateStaticnessOp` that reads `detect_static_agents` once per iteration
- Early-returns from `operator()(Agent*)` when static agent detection is disabled, avoiding a virtual call into every agent's `UpdateStaticness` method

## Test plan
- [ ] Existing unit tests pass (`make check`)
- [ ] Verified that simulations with `detect_static_agents = false` (the default) skip per-agent work in this operation