### PR TITLE
Fix neighbor cache not being cleared when search radius increases

### DIFF
--- a/src/core/execution_context/in_place_exec_ctxt.cc
+++ b/src/core/execution_context/in_place_exec_ctxt.cc
@@ -276,6 +276,7 @@ void InPlaceExecutionContext::ForEachNeighbor(
   // Store the search radius to check validity of cache in consecutive use of
   // ForEachNeighbor
   cached_squared_search_radius_ = squared_radius;
+  neighbor_cache_.clear();
 
   // Populate the cache and execute the lambda for each neighbor
   auto for_each = L2F([&](Agent* agent, real_t squared_distance) {


### PR DESCRIPTION
## Summary

I found a bug in the neighbor caching code inside `ForEachNeighbor`. When you have `cache_neighbors` turned on, the cache gets reused across multiple calls. That's fine until someone requests a bigger search radius than before—the cache becomes stale and needs to be rebuilt.

The problem is that the code wasn't clearing out the old cache entries before adding the new ones. So you'd end up with the old neighbors *plus* the new ones, which means duplicates.

---

## Impact

If the cache has duplicate entries, the same neighbor can get processed multiple times in later queries. This can cause:

* Double-counting forces
* Wrong neighbor counts  
* Simulations that give different results depending on whether caching is on or off

The tricky part is nothing actually crashes—it just quietly produces wrong results.

---

## Fix

Just clear the cache before refilling it:

```cpp
cached_squared_search_radius_ = squared_radius;
neighbor_cache_.clear();  // wipe old data
```

Now the cache always has the right neighbors when it gets rebuilt.