### PR TITLE
build: update curl installer script to checkout master by default

### DIFF
--- a/util/install
+++ b/util/install
@@ -5,7 +5,7 @@
 set -e
 
 if [ -z ${BDM_INSTALL} ]; then
-  export BDM_INSTALL=v1.04-patches
+  export BDM_INSTALL=master
 fi
 echo "BDM_INSTALL is set to: $BDM_INSTALL"
 


### PR DESCRIPTION
### Description
Resolves #398.

The quick `curl ... | bash` installation script in `util/install` was hardcoded to explicitly check out and build the `v1.04-patches` branch which has been stagnant for an extended period, leading to outdated dependencies that completely lack support for modern environments like Ubuntu 22.04.

This patch updates the default fallback checkout target within the installer from the deprecated patch branch to `master`. Users will now pull and compile the most modern code stack by default when testing out BioDynaMo.

### Release Notes
- Fixed quick-install bash script defaulting to outdated branches.