### PR TITLE
util/install: use master as default install target

### DIFF
--- a/util/install
+++ b/util/install
@@ -5,7 +5,7 @@
 set -e
 
 if [ -z ${BDM_INSTALL} ]; then
-  export BDM_INSTALL=v1.04-patches
+  export BDM_INSTALL=master
 fi
 echo "BDM_INSTALL is set to: $BDM_INSTALL"
 


### PR DESCRIPTION
Fixes #398.

Update util/install default BDM_INSTALL from v1.04-patches to master.

Only the default changes. If BDM_INSTALL is already set, the script keeps that value.