### PR TITLE
cmake: support gperftools tcmalloc header path

### DIFF
--- a/cmake/Findtcmalloc.cmake
+++ b/cmake/Findtcmalloc.cmake
@@ -12,7 +12,7 @@
 #  TCMALLOC_LIBRARY_DIRS (not cached)
 #  PPROF_EXECUTABLE
 
-find_path(TCMALLOC_INCLUDE_DIR google/tcmalloc.h)
+find_path(TCMALLOC_INCLUDE_DIR NAMES gperftools/tcmalloc.h google/tcmalloc.h)
 foreach(component tcmalloc profiler)
   find_library(TCMALLOC_${component}_LIBRARY NAMES ${component})
   mark_as_advanced(TCMALLOC_${component}_LIBRARY)


### PR DESCRIPTION
Fixes #396.

This keeps Findtcmalloc.cmake behavior unchanged except for header detection: it now looks for gperftools/tcmalloc.h first and keeps google/tcmalloc.h as fallback for compatibility.

No other build logic was changed.
