### PR TITLE
cmake: locate tcmalloc via gperftools header and library

### DIFF
--- a/cmake/Findtcmalloc.cmake
+++ b/cmake/Findtcmalloc.cmake
@@ -12,7 +12,12 @@
 #  TCMALLOC_LIBRARY_DIRS (not cached)
 #  PPROF_EXECUTABLE
 
-find_path(TCMALLOC_INCLUDE_DIR google/tcmalloc.h)
+# BioDynaMo only links against tcmalloc and never includes its headers, so the
+# include directory is not required for the package to be considered found. We
+# still try to locate a header to use as a hint for finding the pprof binary.
+# Modern gperftools ships <gperftools/tcmalloc.h>; the legacy <google/tcmalloc.h>
+# path has been deprecated for years but is kept as a fallback.
+find_path(TCMALLOC_INCLUDE_DIR NAMES gperftools/tcmalloc.h google/tcmalloc.h)
 foreach(component tcmalloc profiler)
   find_library(TCMALLOC_${component}_LIBRARY NAMES ${component})
   mark_as_advanced(TCMALLOC_${component}_LIBRARY)
@@ -25,9 +30,10 @@ set(TCMALLOC_INCLUDE_DIRS ${TCMALLOC_INCLUDE_DIR})
 set(TCMALLOC_LIBRARIES ${TCMALLOC_tcmalloc_LIBRARY} ${TCMALLOC_profiler_LIBRARY})
 
 # handle the QUIETLY and REQUIRED arguments and set TCMALLOC_FOUND to TRUE if
-# all listed variables are TRUE
+# all listed variables are TRUE. Detection is based on the library alone, since
+# the headers are not needed to build BioDynaMo.
 INCLUDE(FindPackageHandleStandardArgs)
-FIND_PACKAGE_HANDLE_STANDARD_ARGS(tcmalloc DEFAULT_MSG TCMALLOC_INCLUDE_DIR TCMALLOC_LIBRARIES)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(tcmalloc DEFAULT_MSG TCMALLOC_LIBRARIES)
 
 mark_as_advanced(TCMALLOC_FOUND TCMALLOC_INCLUDE_DIR PPROF_EXECUTABLE)
 


### PR DESCRIPTION
## Summary

Fixes #396.

`cmake/Findtcmalloc.cmake` located tcmalloc by searching for the header
`google/tcmalloc.h` — a path gperftools deprecated more than a decade ago.
Current gperftools releases ship `gperftools/tcmalloc.h` instead, so on modern
systems `find_path` failed. Because `TCMALLOC_INCLUDE_DIR` was a **required**
argument to `FIND_PACKAGE_HANDLE_STANDARD_ARGS`, tcmalloc was reported as *not
found* even when `libtcmalloc` was installed and linkable.

As the issue reporter notes, BioDynaMo only **links** against tcmalloc
(`-ltcmalloc`) and never `#include`s its headers, so the include directory is
not needed to build at all.

## Changes

- Search for `gperftools/tcmalloc.h` first, keeping `google/tcmalloc.h` as a
  fallback. The header is now used **only** as a hint to locate the `pprof`
  binary, not as a hard requirement.
- Drop `TCMALLOC_INCLUDE_DIR` from the required arguments of
  `FIND_PACKAGE_HANDLE_STANDARD_ARGS`, so detection is based on the library
  alone.

I confirmed `TCMALLOC_INCLUDE_DIR` / `TCMALLOC_INCLUDE_DIRS` are never consumed
by any compile/include path in the project (only `TCMALLOC_FOUND` and the
`-ltcmalloc` linker flags are used), so dropping the header requirement cannot
affect compilation.

## Testing

Verified against **gperftools 2.18.1**, which ships only `gperftools/tcmalloc.h`
(no `google/tcmalloc.h`), using a minimal `find_package(tcmalloc)` harness:

| Module | Result |
| --- | --- |
| before | `Could NOT find tcmalloc (missing: TCMALLOC_INCLUDE_DIR)` → `TCMALLOC_FOUND=FALSE` (despite `libtcmalloc.dylib` being found) |
| after  | `Found tcmalloc: .../libtcmalloc.dylib;.../libprofiler.dylib` → `TCMALLOC_FOUND=TRUE` |

The change is confined to `cmake/Findtcmalloc.cmake`; `tcmalloc` is `OFF` by
default, so default builds are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
