### PR TITLE
Repair CI

### DIFF
--- a/.github/workflows/singularity-integration.yml
+++ b/.github/workflows/singularity-integration.yml
@@ -16,7 +16,7 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     container:
-      image: quay.io/singularity/singularity:v3.9.0
+      image: quay.io/singularity/singularity:v4.3.1
       options: "--privileged --workdir /data"
     steps:
       - uses: actions/checkout@v4

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -805,9 +805,9 @@ install_inside_build()
 #---Populate the configure arguments returned by 'bdm-config --config'
 get_cmake_property(variables CACHE_VARIABLES)
 foreach(var ${variables})
-  if((var MATCHES "_(LIBRARIES|LIBRARY|INCLUDE|VERSION)") AND
-     (NOT ${${var}} STREQUAL "") AND
-     (NOT ${var} MATCHES "NOTFOUND"))
+  if(("${var}" MATCHES "_(LIBRARIES|LIBRARY|INCLUDE|VERSION)") AND
+     (NOT "${${var}}" STREQUAL "") AND
+     (NOT "${${var}}" MATCHES "NOTFOUND"))
     if (var MATCHES "^QT_")
       # filter out the very long list of Qt libraries and include dirs
       if (var MATCHES "(QT_LIBRARY_DIR|QT_QTCORE_INCLUDE_DIR)")


### PR DESCRIPTION
Restore the repository's supported CI build configurations.

- The architecture job selected the earlier distribution image. Select the updated distribution image. [`.github/workflows/singularity-integration.yml`](https://github.com/BioDynaMo/biodynamo/pull/475/changes#diff-e24ede4631bf32f28394cdba53f1d61224762d0754e777a9ddcbfa4da4894668)
- CMake cache filtering parsed unquoted values and tested a variable name for the NOTFOUND marker. Retain only defined cache values by quoting names and expanded values. [`CMakeLists.txt`](https://github.com/BioDynaMo/biodynamo/pull/475/changes#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20a)
